### PR TITLE
UTCI stress categories

### DIFF
--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1096,6 +1096,8 @@ def utci(tdb, tr, v, rh, units="SI"):
     -------
     utci : float
          Universal Thermal Climate Index, [°C] or in [°F]
+    Stress Category : str
+         UTCI categorized in terms of thermal stress.
 
     Notes
     -----
@@ -1521,11 +1523,31 @@ def utci(tdb, tr, v, rh, units="SI"):
         + 0.00148348065 * pa * pa * pa * pa * pa * pa
     )
 
+    if utci_approx < -40:
+        stress_category = 'extreme cold stress'
+    elif utci_approx < -27:
+        stress_category = 'very strong cold stress'
+    elif utci_approx < -13:
+        stress_category = 'strong cold stress'
+    elif utci_approx < 0:
+        stress_category = 'moderate cold stress'
+    elif utci_approx < 9:
+        stress_category = 'slight cold stress'
+    elif utci_approx < 26:
+        stress_category = 'no thermal stress'
+    elif utci_approx < 32:
+        stress_category = 'moderate heat stress'
+    elif utci_approx < 38:
+        stress_category = 'strong heat stress'
+    elif utci_approx < 46:
+        stress_category = 'very strong heat stress'
+    else:
+        stress_category = 'extreme heat stress'
+
     if units.lower() == "ip":
         utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
 
-    return round(utci_approx, 1)
-
+    return {"utci": round(utci_approx, 1), "Stress Category": stress_category}
 
 def clo_tout(tout, units="SI"):
     """Representative clothing insulation Icl as a function of outdoor air temperature

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1066,7 +1066,7 @@ def adaptive_en(tdb, tr, t_running_mean, v, units="SI"):
     return results
 
 
-def utci(tdb, tr, v, rh, units="SI"):
+def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
     """Determines the Universal Thermal Climate Index (UTCI). The UTCI is the
     equivalent temperature for the environment derived from a reference environment.
     It is defined as the air temperature of the reference environment which produces
@@ -1091,6 +1091,8 @@ def utci(tdb, tr, v, rh, units="SI"):
         relative humidity, [%]
     units: str default="SI"
         select the SI (International System of Units) or the IP (Imperial Units) system.
+    return_stress_category : boolean default False
+        if True returns the UTCI categorized in terms of thermal stress.
 
     Returns
     -------
@@ -1547,7 +1549,11 @@ def utci(tdb, tr, v, rh, units="SI"):
     if units.lower() == "ip":
         utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
 
-    return {"utci": round(utci_approx, 1), "Stress Category": stress_category}
+    if return_stress_category:
+        return {"utci": round(utci_approx, 1), "Stress Category": stress_category}
+    else:
+        return round(utci_approx, 1)
+
 
 def clo_tout(tout, units="SI"):
     """Representative clothing insulation Icl as a function of outdoor air temperature

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -692,11 +692,11 @@ def test_utci():
         ]
     )
     for row in data_test_adaptive_ashrae:
-        assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])) == row["return"][
+        assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])["utci"]) == row["return"][
             list(row["return"].keys())[0]
         ]
 
-    assert (utci(tdb=77, tr=77, v=3.28, rh=50, units="ip")) == 76.4
+    assert (utci(tdb=77, tr=77, v=3.28, rh=50, units="ip")["utci"]) == 76.4
 
 
 def test_clo_dynamic():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -692,11 +692,11 @@ def test_utci():
         ]
     )
     for row in data_test_adaptive_ashrae:
-        assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])["utci"]) == row["return"][
+        assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])) == row["return"][
             list(row["return"].keys())[0]
         ]
 
-    assert (utci(tdb=77, tr=77, v=3.28, rh=50, units="ip")["utci"]) == 76.4
+    assert (utci(tdb=77, tr=77, v=3.28, rh=50, units="ip")) == 76.4
 
 
 def test_clo_dynamic():


### PR DESCRIPTION
Issue #12
This adds the UTCI stress category (a string) to the output of models.utci.
Alternatively, this could be split into a separate function so that the output of models.utci remains a float.