### PR TITLE
utci numpy

### DIFF
--- a/examples/calc_utci.py
+++ b/examples/calc_utci.py
@@ -12,18 +12,18 @@ print(utci_val)
 
 # numpy examples
 utci_val = utci(
-    tdb=np.array([29, 29]),
-    tr=np.array([30, 30]),
-    v=np.array([1, 2]),
-    rh=np.array([60, 60]),
+    tdb=np.array([29, 29, 25]),
+    tr=np.array([30, 30, 25]),
+    v=np.array([1, 2, 1]),
+    rh=np.array([60, 60, 50]),
 )
 print(utci_val)
 
 utci_val = utci(
-    tdb=np.array([29, 29]),
-    tr=np.array([30, 30]),
-    v=np.array([1, 2]),
-    rh=np.array([60, 60]),
+    tdb=np.array([29, 29, 25]),
+    tr=np.array([30, 30, 25]),
+    v=np.array([1, 2, 1]),
+    rh=np.array([60, 60, 50]),
     return_stress_category=True,
 )
 print(utci_val)

--- a/examples/calc_utci.py
+++ b/examples/calc_utci.py
@@ -1,4 +1,5 @@
 from pythermalcomfort.models import utci
+import numpy as np
 
 utci_val = utci(tdb=29, tr=30, v=1, rh=60)
 print(utci_val)
@@ -7,4 +8,22 @@ utci_val = utci(tdb=29, tr=30, v=2, rh=60)
 print(utci_val)
 
 utci_val = utci(tdb=77, tr=77, v=6.56168, rh=60, units="IP")
+print(utci_val)
+
+# numpy examples
+utci_val = utci(
+    tdb=np.array([29, 29]),
+    tr=np.array([30, 30]),
+    v=np.array([1, 2]),
+    rh=np.array([60, 60]),
+)
+print(utci_val)
+
+utci_val = utci(
+    tdb=np.array([29, 29]),
+    tr=np.array([30, 30]),
+    v=np.array([1, 2]),
+    rh=np.array([60, 60]),
+    return_stress_category=True,
+)
 print(utci_val)

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "buit environment",
     ],
     python_requires=">=3.6.*",
-    install_requires=["scipy", "numba", "jos3"],  # eg: 'aspectlib==1.1.1', 'six>=1.7',
+    install_requires=["scipy", "numba", "jos3", "numpy"],  # eg: 'aspectlib==1.1.1', 'six>=1.7',
     extras_require={
         # eg:
         #   'rst': ['docutils>=0.11'],

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1105,35 +1105,13 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
 
     utci_approx = np.where(all_valid, utci_approx, np.nan)
 
-    return np.round_(utci_approx, 1)
-    #if utci_approx < -40:
-    #    stress_category = "extreme cold stress"
-    #elif utci_approx < -27:
-    #    stress_category = "very strong cold stress"
-    #elif utci_approx < -13:
-    #    stress_category = "strong cold stress"
-    #elif utci_approx < 0:
-    #    stress_category = "moderate cold stress"
-    #elif utci_approx < 9:
-    #    stress_category = "slight cold stress"
-    #elif utci_approx < 26:
-    #    stress_category = "no thermal stress"
-    #elif utci_approx < 32:
-    #    stress_category = "moderate heat stress"
-    #elif utci_approx < 38:
-    #    stress_category = "strong heat stress"
-    #elif utci_approx < 46:
-    #    stress_category = "very strong heat stress"
-    #else:
-    #    stress_category = "extreme heat stress"
+    if units.lower() == "ip":
+        utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
 
-    #if units.lower() == "ip":
-    #    utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
-
-    #if return_stress_category:
-    #    return {"utci": round(utci_approx, 1), "stress_category": stress_category}
-    #else:
-    #    return round(utci_approx, 1)
+    if return_stress_category:
+        return {"utci": np.round_(utci_approx, 1), "stress_category": map_stress_category(utci_approx)}
+    else:
+        return np.round_(utci_approx, 1)
 
 
 def clo_tout(tout, units="SI"):
@@ -2417,6 +2395,25 @@ def use_fans_morris(
 
     return tipping_point
 
+
+def map_stress_category(t):
+    """Maps a temperature array to stress categories."""
+
+    thresholds = {-40.:'extreme cold stress',
+                   -27.:'very strong cold stress',
+                   -13.:'strong cold stress',
+                     0.: 'moderate cold stress',
+                    9.: 'slight cold stress',
+                    26.: 'no thermal stress', 
+                    32.: 'moderate heat stress',
+                    38.: 'strong heat stress',
+                    46.: 'very strong heat stress',
+                   1000.: 'extreme heat stress'}
+    
+    bins = np.array(list(thresholds.keys()))
+    words = np.append(np.array(list(thresholds.values())), 'unknown')
+    return words[np.digitize(t, bins, right=True)]
+    
 
 # # testing morris equation
 # from scipy import optimize

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1018,13 +1018,13 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
 
     Parameters
     ----------
-    tdb : float
+    tdb : float, array_like
         dry bulb air temperature, default in [°C] in [°F] if `units` = 'IP'
-    tr : float
+    tr : float, array_like
         mean radiant temperature, default in [°C] in [°F] if `units` = 'IP'
-    v : float
+    v : float, array_like
         wind speed 10m above ground level, default in [m/s] in [fps] if `units` = 'IP'
-    rh : float
+    rh : float, array_like
         relative humidity, [%]
     units: str default="SI"
         select the SI (International System of Units) or the IP (Imperial Units) system.
@@ -1033,9 +1033,9 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
 
     Returns
     -------
-    utci : float
+    utci : float, array_like
          Universal Thermal Climate Index, [°C] or in [°F]
-    stress_category : str
+    stress_category : str, array_like
          UTCI categorized in terms of thermal stress [9]_.
 
     Notes

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1071,7 +1071,7 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
     if units.lower() == "ip":
         tdb, tr, v = units_converter(tdb=tdb, tr=tr, v=v)
 
-    #check_standard_compliance(standard="utci", tdb=tdb, tr=tr, v=v)
+    # check_standard_compliance(standard="utci", tdb=tdb, tr=tr, v=v)
 
     def exponential(t_db):
         g = [
@@ -1092,9 +1092,9 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
 
     # Do a series of checks to be sure that the input values are within the bounds
     # accepted by the model.
-    tdb_valid = valid_range(tdb, (-50.,50.))
-    diff_valid = valid_range(tr - tdb, (-30.,70.))
-    v_valid = valid_range(v, (0.5, 17.))
+    tdb_valid = valid_range(tdb, (-50.0, 50.0))
+    diff_valid = valid_range(tr - tdb, (-30.0, 70.0))
+    v_valid = valid_range(v, (0.5, 17.0))
     all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
 
     eh_pa = exponential(tdb) * (rh / 100.0)
@@ -1109,7 +1109,10 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
         utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
 
     if return_stress_category:
-        return {"utci": np.round_(utci_approx, 1), "stress_category": map_stress_category(utci_approx)}
+        return {
+            "utci": np.round_(utci_approx, 1),
+            "stress_category": map_stress_category(utci_approx),
+        }
     else:
         return np.round_(utci_approx, 1)
 
@@ -2399,21 +2402,23 @@ def use_fans_morris(
 def map_stress_category(t):
     """Maps a temperature array to stress categories."""
 
-    thresholds = {-40.:'extreme cold stress',
-                   -27.:'very strong cold stress',
-                   -13.:'strong cold stress',
-                     0.: 'moderate cold stress',
-                    9.: 'slight cold stress',
-                    26.: 'no thermal stress', 
-                    32.: 'moderate heat stress',
-                    38.: 'strong heat stress',
-                    46.: 'very strong heat stress',
-                   1000.: 'extreme heat stress'}
-    
+    thresholds = {
+        -40.0: "extreme cold stress",
+        -27.0: "very strong cold stress",
+        -13.0: "strong cold stress",
+        0.0: "moderate cold stress",
+        9.0: "slight cold stress",
+        26.0: "no thermal stress",
+        32.0: "moderate heat stress",
+        38.0: "strong heat stress",
+        46.0: "very strong heat stress",
+        1000.0: "extreme heat stress",
+    }
+
     bins = np.array(list(thresholds.keys()))
-    words = np.append(np.array(list(thresholds.values())), 'unknown')
+    words = np.append(np.array(list(thresholds.values())), "unknown")
     return words[np.digitize(t, bins, right=True)]
-    
+
 
 # # testing morris equation
 # from scipy import optimize

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1034,7 +1034,7 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False, return_invali
     return_invald : boolean default False
         if True returns UTCI values also if input values are outside of the applicability 
         limits of the model. The valid input ranges are for air temperature tdb [°C]: (-50, 50), 
-        for radiant temperature tr [°C]: (tdb - 30, tdb + 70) and for wind spped v [m/s]: (0.5, 17.0).
+        for radiant temperature tr [°C]: (tdb - 70, tdb + 30) and for wind spped v [m/s]: (0.5, 17.0).
         By default, invalid input ranges will return nan.
 
     Returns

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -6,6 +6,7 @@ from pythermalcomfort.utilities import (
     transpose_sharp_altitude,
     check_standard_compliance,
     valid_range,
+    map_stress_category,
 )
 import math
 from scipy import optimize
@@ -2397,27 +2398,6 @@ def use_fans_morris(
     tipping_point = (e_req_off - e_req_on) - (combined_e_max_off - combined_e_max_on)
 
     return tipping_point
-
-
-def map_stress_category(t):
-    """Maps a temperature array to stress categories."""
-
-    thresholds = {
-        -40.0: "extreme cold stress",
-        -27.0: "very strong cold stress",
-        -13.0: "strong cold stress",
-        0.0: "moderate cold stress",
-        9.0: "slight cold stress",
-        26.0: "no thermal stress",
-        32.0: "moderate heat stress",
-        38.0: "strong heat stress",
-        46.0: "very strong heat stress",
-        1000.0: "extreme heat stress",
-    }
-
-    bins = np.array(list(thresholds.keys()))
-    words = np.append(np.array(list(thresholds.values())), "unknown")
-    return words[np.digitize(t, bins, right=True)]
 
 
 # # testing morris equation

--- a/src/pythermalcomfort/models.py
+++ b/src/pythermalcomfort/models.py
@@ -1,9 +1,11 @@
+import numpy as np
 import warnings
 from pythermalcomfort.psychrometrics import t_o, p_sat_torr, p_sat, psy_ta_rh
 from pythermalcomfort.utilities import (
     units_converter,
     transpose_sharp_altitude,
     check_standard_compliance,
+    valid_range,
 )
 import math
 from scipy import optimize
@@ -1069,7 +1071,7 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
     if units.lower() == "ip":
         tdb, tr, v = units_converter(tdb=tdb, tr=tr, v=v)
 
-    check_standard_compliance(standard="utci", tdb=tdb, tr=tr, v=v)
+    #check_standard_compliance(standard="utci", tdb=tdb, tr=tr, v=v)
 
     def exponential(t_db):
         g = [
@@ -1082,25 +1084,18 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
             (-1.8680009 * (10 ** (-13))),
         ]
         tk = t_db + 273.15  # air temp in K
-        es = 2.7150305 * math.log1p(tk)
+        es = 2.7150305 * np.log1p(tk)
         for count, i in enumerate(g):
             es = es + (i * (tk ** (count - 2)))
-        es = math.exp(es) * 0.01  # convert Pa to hPa
+        es = np.exp(es) * 0.01  # convert Pa to hPa
         return es
 
     # Do a series of checks to be sure that the input values are within the bounds
     # accepted by the model.
-    if (
-        (tdb < -50.0)
-        or (tdb > 50.0)
-        or (tr - tdb < -30.0)
-        or (tr - tdb > 70.0)
-        or (v < 0.5)
-        or (v > 17)
-    ):
-        raise ValueError(
-            "The value you entered are outside the equation applicability limits"
-        )
+    tdb_valid = valid_range(tdb, (-50.,50.))
+    diff_valid = valid_range(tr - tdb, (-30.,70.))
+    v_valid = valid_range(v, (0.5, 17.))
+    all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
 
     eh_pa = exponential(tdb) * (rh / 100.0)
     delta_t_tr = tr - tdb
@@ -1108,34 +1103,37 @@ def utci(tdb, tr, v, rh, units="SI", return_stress_category=False):
 
     utci_approx = utci_optimized(tdb, v, delta_t_tr, pa)
 
-    if utci_approx < -40:
-        stress_category = "extreme cold stress"
-    elif utci_approx < -27:
-        stress_category = "very strong cold stress"
-    elif utci_approx < -13:
-        stress_category = "strong cold stress"
-    elif utci_approx < 0:
-        stress_category = "moderate cold stress"
-    elif utci_approx < 9:
-        stress_category = "slight cold stress"
-    elif utci_approx < 26:
-        stress_category = "no thermal stress"
-    elif utci_approx < 32:
-        stress_category = "moderate heat stress"
-    elif utci_approx < 38:
-        stress_category = "strong heat stress"
-    elif utci_approx < 46:
-        stress_category = "very strong heat stress"
-    else:
-        stress_category = "extreme heat stress"
+    utci_approx = np.where(all_valid, utci_approx, np.nan)
 
-    if units.lower() == "ip":
-        utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
+    return np.round_(utci_approx, 1)
+    #if utci_approx < -40:
+    #    stress_category = "extreme cold stress"
+    #elif utci_approx < -27:
+    #    stress_category = "very strong cold stress"
+    #elif utci_approx < -13:
+    #    stress_category = "strong cold stress"
+    #elif utci_approx < 0:
+    #    stress_category = "moderate cold stress"
+    #elif utci_approx < 9:
+    #    stress_category = "slight cold stress"
+    #elif utci_approx < 26:
+    #    stress_category = "no thermal stress"
+    #elif utci_approx < 32:
+    #    stress_category = "moderate heat stress"
+    #elif utci_approx < 38:
+    #    stress_category = "strong heat stress"
+    #elif utci_approx < 46:
+    #    stress_category = "very strong heat stress"
+    #else:
+    #    stress_category = "extreme heat stress"
 
-    if return_stress_category:
-        return {"utci": round(utci_approx, 1), "stress_category": stress_category}
-    else:
-        return round(utci_approx, 1)
+    #if units.lower() == "ip":
+    #    utci_approx = units_converter(tmp=utci_approx, from_units="si")[0]
+
+    #if return_stress_category:
+    #    return {"utci": round(utci_approx, 1), "stress_category": stress_category}
+    #else:
+    #    return round(utci_approx, 1)
 
 
 def clo_tout(tout, units="SI"):

--- a/src/pythermalcomfort/utilities.py
+++ b/src/pythermalcomfort/utilities.py
@@ -367,6 +367,36 @@ def units_converter(from_units="ip", **kwargs):
     return results
 
 
+def map_stress_category(t):
+    """Maps a temperature array to stress categories.
+
+    Parameters
+    ----------
+    t: float, array_like
+        Temperature to map.
+
+    Returns
+    -------
+    Stress category for each input temperature.
+    """
+    thresholds = {
+        -40.0: "extreme cold stress",
+        -27.0: "very strong cold stress",
+        -13.0: "strong cold stress",
+        0.0: "moderate cold stress",
+        9.0: "slight cold stress",
+        26.0: "no thermal stress",
+        32.0: "moderate heat stress",
+        38.0: "strong heat stress",
+        46.0: "very strong heat stress",
+        1000.0: "extreme heat stress",
+    }
+
+    bins = np.array(list(thresholds.keys()))
+    words = np.append(np.array(list(thresholds.values())), "unknown")
+    return words[np.digitize(t, bins, right=True)]
+
+
 #: Met values of typical tasks.
 met_typical_tasks = {
     "Sleeping": 0.7,

--- a/src/pythermalcomfort/utilities.py
+++ b/src/pythermalcomfort/utilities.py
@@ -1,8 +1,19 @@
+import numpy as np
 import warnings
 import math
 from pythermalcomfort.psychrometrics import p_sat
 
 warnings.simplefilter("always")
+
+
+def valid_range(x, valid):
+    """Filter values based on a valid range."""
+    return np.where((x > valid[0]) & (x < valid[1]), x, np.nan)
+
+
+def is_valid(x, valid):
+    """Return a mask based on a valid range."""
+    return (x > valid[0]) & (x < valid[1])
 
 
 def transpose_sharp_altitude(sharp, altitude):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1005,7 +1005,7 @@ def test_t_globe():
 
 
 def test_set_tmp():
-    """ Test the PMV function using the reference table from the ASHRAE 55 2020"""
+    """Test the PMV function using the reference table from the ASHRAE 55 2020"""
     for row in data_test_set:
         assert (
             abs(
@@ -1070,7 +1070,7 @@ def test_set_tmp():
 
 
 def test_pmv():
-    """ Test the PMV function using the reference table from the ASHRAE 55 2020"""
+    """Test the PMV function using the reference table from the ASHRAE 55 2020"""
     for row in data_test_pmv:
         assert (
             round(
@@ -1083,7 +1083,7 @@ def test_pmv():
 
 
 def test_pmv_ppd():
-    """ Test the PMV function using the reference table from the ASHRAE 55 2020"""
+    """Test the PMV function using the reference table from the ASHRAE 55 2020"""
     for row in data_test_pmv:
         assert (
             abs(
@@ -1348,16 +1348,14 @@ def test_ankle_draft():
 
 @pytest.fixture
 def data_test_adaptive_ashrae():
-    return (
-        [  # I have commented the lines of code that don't pass the test
-            {"tdb": 25, "tr": 27, "rh": 50, "v": 1, "return": {"utci": 25.2}},
-            {"tdb": 19, "tr": 24, "rh": 50, "v": 1, "return": {"utci": 20.0}},
-            {"tdb": 19, "tr": 14, "rh": 50, "v": 1, "return": {"utci": 16.8}},
-            {"tdb": 27, "tr": 22, "rh": 50, "v": 1, "return": {"utci": 25.5}},
-            {"tdb": 27, "tr": 22, "rh": 50, "v": 10, "return": {"utci": 20.0}},
-            {"tdb": 27, "tr": 22, "rh": 50, "v": 16, "return": {"utci": 15.8}},
-        ]
-    )
+    return [  # I have commented the lines of code that don't pass the test
+        {"tdb": 25, "tr": 27, "rh": 50, "v": 1, "return": {"utci": 25.2}},
+        {"tdb": 19, "tr": 24, "rh": 50, "v": 1, "return": {"utci": 20.0}},
+        {"tdb": 19, "tr": 14, "rh": 50, "v": 1, "return": {"utci": 16.8}},
+        {"tdb": 27, "tr": 22, "rh": 50, "v": 1, "return": {"utci": 25.5}},
+        {"tdb": 27, "tr": 22, "rh": 50, "v": 10, "return": {"utci": 20.0}},
+        {"tdb": 27, "tr": 22, "rh": 50, "v": 16, "return": {"utci": 15.8}},
+    ]
 
 
 def test_utci(data_test_adaptive_ashrae):
@@ -1389,7 +1387,10 @@ def test_utci_numpy(data_test_adaptive_ashrae):
     tr = np.array([27, 25])
     v = np.array([1, 1])
     rh = np.array([50, 50])
-    expect = {"utci": np.array([25.2, 24.6]), "stress_category": np.array(["no thermal stress", "no thermal stress"])}
+    expect = {
+        "utci": np.array([25.2, 24.6]),
+        "stress_category": np.array(["no thermal stress", "no thermal stress"]),
+    }
 
     result = utci(tdb, tr, v, rh, units="si", return_stress_category=True)
     np.testing.assert_equal(result["utci"], expect["utci"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1347,7 +1347,7 @@ def test_ankle_draft():
 
 
 @pytest.fixture
-def data_test_adaptive_ashrae():
+def data_test_utci():
     return [  # I have commented the lines of code that don't pass the test
         {"tdb": 25, "tr": 27, "rh": 50, "v": 1, "return": {"utci": 25.2}},
         {"tdb": 19, "tr": 24, "rh": 50, "v": 1, "return": {"utci": 20.0}},
@@ -1358,8 +1358,8 @@ def data_test_adaptive_ashrae():
     ]
 
 
-def test_utci(data_test_adaptive_ashrae):
-    for row in data_test_adaptive_ashrae:
+def test_utci(data_test_utci):
+    for row in data_test_utci:
         assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])) == row["return"][
             list(row["return"].keys())[0]
         ]
@@ -1374,12 +1374,12 @@ def test_utci(data_test_adaptive_ashrae):
     ) == {"utci": 24.6, "stress_category": "no thermal stress"}
 
 
-def test_utci_numpy(data_test_adaptive_ashrae):
-    tdb = np.array([d["tdb"] for d in data_test_adaptive_ashrae])
-    tr = np.array([d["tr"] for d in data_test_adaptive_ashrae])
-    rh = np.array([d["rh"] for d in data_test_adaptive_ashrae])
-    v = np.array([d["v"] for d in data_test_adaptive_ashrae])
-    expect = np.array([d["return"]["utci"] for d in data_test_adaptive_ashrae])
+def test_utci_numpy(data_test_utci):
+    tdb = np.array([d["tdb"] for d in data_test_utci])
+    tr = np.array([d["tr"] for d in data_test_utci])
+    rh = np.array([d["rh"] for d in data_test_utci])
+    v = np.array([d["v"] for d in data_test_utci])
+    expect = np.array([d["return"]["utci"] for d in data_test_utci])
 
     np.testing.assert_equal(utci(tdb, tr, v, rh), expect)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1355,14 +1355,17 @@ def data_test_utci():
         {"tdb": 27, "tr": 22, "rh": 50, "v": 1, "return": {"utci": 25.5}},
         {"tdb": 27, "tr": 22, "rh": 50, "v": 10, "return": {"utci": 20.0}},
         {"tdb": 27, "tr": 22, "rh": 50, "v": 16, "return": {"utci": 15.8}},
+        {"tdb": 51, "tr": 22, "rh": 50, "v": 16, "return": {"utci": np.nan}},
+        {"tdb": 27, "tr": 22, "rh": 50, "v": 0, "return": {"utci": np.nan}},
     ]
 
 
 def test_utci(data_test_utci):
     for row in data_test_utci:
-        assert (utci(row["tdb"], row["tr"], row["v"], row["rh"])) == row["return"][
-            list(row["return"].keys())[0]
-        ]
+        np.testing.assert_equal(
+            utci(row["tdb"], row["tr"], row["v"], row["rh"]),
+            row["return"][list(row["return"].keys())[0]],
+        )
 
     assert (utci(tdb=77, tr=77, v=3.28, rh=50, units="ip")) == 76.4
 


### PR DESCRIPTION
I would like to have comfort indicators work on numpy array. Here i start with `utci`:

to do:

- [x] replace `if` statements with `np.where`
- [x] removed `ValueError` and warnings for invalid input ranges, return `np.nan` instead.
- [x] replaced stress category `if` statements with `np.digitize` binning.
- [x] add examples
- [ ] update docs
- [x] add tests
- [ ] add test for invalid input
- [ ] add example notebook

It all should still work with floats but now also with numpy arrays (and much faster than using `np.vectorize`)

closes #23 