### PR TITLE
allow n-dimensional arrays for pet_steady, speedup p_sat calculation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,10 +6,12 @@ Authors
 * `Stefano Schiavon`_
 * `Tyler Hoyt`_
 * Chris Mackey
+* `Jonas Kittner`_
 
 .. _Federico Tartarini: https://www.linkedin.com/in/federico-tartarini-3991995b/
 .. _Stefano Schiavon: https://www.linkedin.com/in/stefanoschiavon/
 .. _Tyler Hoyt: https://www.linkedin.com/in/tyler-hoyt1/
+.. _Jonas Kittner: https://github.com/jkittner/
 
 **Derivative work**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.10.0 (unreleased)
+-------------------
+
+* allow n-dimensional arrays for ``pet_steady`` and speedup ``p_sat`` calculation
+
+
 2.9.1 (2024-01-19)
 -------------------
 

--- a/pythermalcomfort/models/pet_steady.py
+++ b/pythermalcomfort/models/pet_steady.py
@@ -1,4 +1,7 @@
+from typing import  Literal, Any, Union
+
 import numpy as np
+import numpy.typing as npt
 from scipy import optimize
 
 from pythermalcomfort.psychrometrics import p_sat
@@ -7,21 +10,22 @@ from pythermalcomfort.utilities import (
 )
 
 
+@np.vectorize
 def pet_steady(
-    tdb,
-    tr,
-    v,
-    rh,
-    met,
-    clo,
-    p_atm=1013.25,
-    position=1,
-    age=23,
-    sex=1,
-    weight=75,
-    height=1.8,
-    wme=0,
-):
+    tdb: npt.ArrayLike,
+    tr: npt.ArrayLike,
+    v: npt.ArrayLike,
+    rh: npt.ArrayLike,
+    met: npt.ArrayLike,
+    clo: npt.ArrayLike,
+    p_atm: npt.ArrayLike = 1013.25,
+    position: Union[npt.ArrayLike, Literal[1, 2, 3]] = 1,
+    age: npt.ArrayLike = 23,
+    sex: Union[npt.ArrayLike, Literal[1, 2]] = 1,
+    weight: npt.ArrayLike = 75,
+    height: npt.ArrayLike = 1.8,
+    wme: npt.ArrayLike = 0,
+) -> Union[npt.NDArray[Any], float]:
     """
     The steady physiological equivalent temperature (PET) is calculated using the Munich
     Energy-balance Model for Individuals (MEMI), which simulates the human body's thermal
@@ -43,31 +47,31 @@ def pet_steady(
 
     Parameters
     ----------
-    tdb : float
+    tdb : float or array-like
         dry bulb air temperature, [°C]
-    tr : float
+    tr : float or array-like
         mean radiant temperature, [°C]
-    v : float
+    v : float or array-like
         air speed, [m/s]
-    rh : float
+    rh : float or array-like
         relative humidity, [%]
-    met : float
+    met : float or array-like
         metabolic rate, [met]
-    clo : float
+    clo : float or array-like
         clothing insulation, [clo]
-    p_atm : float
+    p_atm : float or array-like
         atmospheric pressure, default value 1013.25 [hPa]
-    position : int
+    position : int or array-like
         position of the individual (1=sitting, 2=standing, 3=standing, forced convection)
-    age : int, default 23
+    age : int or array-like, default 23
         age in years
-    sex : int, default 1
+    sex : int or array-like, default 1
         male (1) or female (2).
-    weight : float, default 75
+    weight : float or array-like, default 75
         body mass, [kg]
-    height: float, default 1.8
-        height, [m]
-    wme : float, default 0
+    height: float or array-like, default 1.8
+        height or array-like, [m]
+    wme : float or array-like, default 0
         external work, [W/(m2)] default 0
 
     Returns

--- a/pythermalcomfort/psychrometrics.py
+++ b/pythermalcomfort/psychrometrics.py
@@ -89,6 +89,21 @@ def enthalpy(
 
     return round(h, 2)
 
+# pre-calculated constants for p_sat
+c1 = -5674.5359
+c2 = 6.3925247
+c3 = -0.9677843 * 1e-2
+c4 = 0.62215701 * 1e-6
+c5 = 0.20747825 * 1e-8
+c6 = -0.9484024 * 1e-12
+c7 = 4.1635019
+c8 = -5800.2206
+c9 = 1.3914993
+c10 = -0.048640239
+c11 = 0.41764768 * 1e-4
+c12 = -0.14452093 * 1e-7
+c13 = 6.5459673
+
 
 def p_sat(tdb: Union[float, int, np.ndarray, List[float], List[int]]):
     """Calculates vapour pressure of water at different temperatures
@@ -105,37 +120,25 @@ def p_sat(tdb: Union[float, int, np.ndarray, List[float], List[int]]):
     """
 
     ta_k = tdb + c_to_k
-    c1 = -5674.5359
-    c2 = 6.3925247
-    c3 = -0.9677843 * 1e-2
-    c4 = 0.62215701 * 1e-6
-    c5 = 0.20747825 * 1e-8
-    c6 = -0.9484024 * 1e-12
-    c7 = 4.1635019
-    c8 = -5800.2206
-    c9 = 1.3914993
-    c10 = -0.048640239
-    c11 = 0.41764768 * 1e-4
-    c12 = -0.14452093 * 1e-7
-    c13 = 6.5459673
-
+    # pre-calculate the value before passing it to .where
+    log_ta_k = np.log(ta_k)
     pascals = np.where(
         ta_k < c_to_k,
         np.exp(
             c1 / ta_k
             + c2
             + ta_k * (c3 + ta_k * (c4 + ta_k * (c5 + c6 * ta_k)))
-            + c7 * np.log(ta_k)
+            + c7 * log_ta_k
         ),
         np.exp(
             c8 / ta_k
             + c9
             + ta_k * (c10 + ta_k * (c11 + ta_k * c12))
-            + c13 * np.log(ta_k)
+            + c13 * log_ta_k
         ),
     )
 
-    return np.around(pascals, 1)
+    return pascals
 
 
 @dataclass

--- a/tests/test_pet_steady.py
+++ b/tests/test_pet_steady.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pythermalcomfort.models import pet_steady
 
 
@@ -28,3 +29,26 @@ def test_pet_steady(get_pet_steady_url, retrieve_data, is_equal):
                 f"Assertion failed for pet_steady. Expected {expected_output}, got {result}, inputs={inputs}\nError: {str(e)}"
             )
             raise
+
+PET_TEST_MATRIX = (
+    # 'tdb', 'tr', 'rh', 'v', 'met', 'clo', 'exp'
+    (20, 20, 50, 0.15, 1.37, 0.5, 18.85),
+    (30, 30, 50, 0.15, 1.37, 0.5, 30.6),
+    (20, 20, 50, 0.5, 1.37, 0.5, 17.16),
+    (21, 21, 50, 0.1, 1.37, 0.9, 21.08),
+    (20, 20, 50, 0.1, 1.37, 0.9, 19.92),
+    (-5, 40, 2, 0.5, 1.37, 0.9, 7.82),
+    (-5, -5, 50, 5.0, 1.37, 0.9, -13.38),
+    (30, 60, 80, 1.0, 1.37, 0.9, 44.63),
+    (30, 30, 80, 1.0, 1.37, 0.9, 32.21),
+)
+
+@pytest.mark.parametrize('shape', ((10, 10), 10, (3, 3, 3)))
+@pytest.mark.parametrize(('tdb', 'tr', 'rh', 'v', 'met', 'clo', 'exp'), PET_TEST_MATRIX)
+def test_pet_array(shape, tdb, tr, rh, v, met, clo, exp):
+    tdb_arr=np.full(shape, tdb)
+    tr_arr=np.full(shape, tr)
+    rh_arr=np.full(shape, rh)
+    v_arr=np.full(shape, v)
+    res = pet_steady(tdb=tdb_arr, tr=tr_arr, rh=rh_arr, v=v_arr, met=met, clo=clo)
+    np.testing.assert_array_equal(actual=res, desired=np.full(shape, exp))

--- a/tests/test_psychrometrics.py
+++ b/tests/test_psychrometrics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pythermalcomfort.psychrometrics import (
     t_dp,
@@ -30,12 +31,12 @@ def test_enthalpy():
 
 def test_psy_ta_rh():
     assert psy_ta_rh(25, 50, p_atm=101325) == PsychrometricValues(
-        p_sat=3169.2,
-        p_vap=1584.6,
-        hr=0.009881547577511219,
+        p_sat=pytest.approx(3169.2, abs=1e-1),
+        p_vap=pytest.approx(1584.6, abs=1e-1),
+        hr=pytest.approx(0.009881547577511219, abs=1e-7),
         t_wb=18.0,
         t_dp=13.8,
-        h=50259.66,
+        h=pytest.approx(50259.79, abs=1e-1),
     )
 
 
@@ -50,8 +51,8 @@ def test_t_o():
 
 
 def test_p_sat():
-    assert (p_sat(tdb=25)) == 3169.2
-    assert (p_sat(tdb=50)) == 12349.9
+    assert pytest.approx(p_sat(tdb=25), abs=1e-1) == 3169.2
+    assert pytest.approx(p_sat(tdb=50), abs=1e-1) == 12349.9
 
 
 def test_t_mrt():


### PR DESCRIPTION
The orignal goal was to be able to pass arrays to the function i.e. allow to use this function in pandas without a `lambda` wrapper. For the tests cases this would like this.

```python
import pandas as pd
from pythermalcomfort.models import pet_steady

df = pd.DataFrame(
    [
        (20, 20, 50, 0.15, 1.37, 0.5),
        (30, 30, 50, 0.15, 1.37, 0.5),
        (20, 20, 50, 0.5, 1.37, 0.5),
        (21, 21, 50, 0.1, 1.37, 0.9),
        (20, 20, 50, 0.1, 1.37, 0.9),
        (-5, 40, 2, 0.5, 1.37, 0.9),
        (-5, -5, 50, 5.0, 1.37, 0.9),
        (30, 60, 80, 1.0, 1.37, 0.9),
        (30, 30, 80, 1.0, 1.37, 0.9),
    ],
    columns=['tdb', 'tr', 'rh', 'v', 'met', 'clo']
)

pet = pet_steady(
    tdb=df['tdb'],
    tr=df['tr'],
    rh=df['rh'],
    v=df['v'],
    met=df['met'],
    clo=df['clo'],
)
```

`np.vectorize` now allows it to also take n-dimensional arrays - this can especially be useful for raster data. For some randome data this would like this.

```python
import numpy as np

np.random.seed(42)

shape = (10, 10)

tdb=np.random.uniform(5, 40, shape)
tr=tr=np.random.uniform(10, 80, shape)
v=tr=np.random.uniform(0.5, 7, shape)
rh=tr=np.random.uniform(35, 80, shape)
pet = pet_steady(tdb=tdb, tr=tr, v=v, rh=rh, met=1.37, clo=0.5)
print(pet)
```

Unfortunately the `pet_steady` function is notoriously slow. A benchmark showed these results:

```python
+--------------+----------------+-----------------------+-----------------------+
| Benchmark    | not_vectorized | before_optimization   | after_optimization    |
+==============+================+=======================+=======================+
| single value | 4.03 ms        | 8.37 ms: 2.07x slower | 3.57 ms: 1.13x faster |
+--------------+----------------+-----------------------+-----------------------+
```

Adding the vectorization caused single values to become even slower, so I tooke a few steps to improve performance. Mostly arrays benefit from this now, but also single values are 1.13x faster.

```python
+------------------+----------+------------------------+
| Benchmark        | before   | after                  |
+==================+==========+========================+
| single value     | 8.37 ms  | 3.57 ms: 2.35x faster  |
+------------------+----------+------------------------+
| 2D array 10x10   | 326 ms   | 180 ms: 1.81x faster   |
+------------------+----------+------------------------+
| 2D array 100x100 | 29.1 sec | 16.8 sec: 1.73x faster |
+------------------+----------+------------------------+
| Geometric mean   | (ref)    | 1.94x faster           |
+------------------+----------+------------------------+
```
2D-arrays are now 1.81x (10x10) or 1.73x (100x100) faster.

The biggest performance gain was achieved by optimizing the `p_sat` (saturation vapor pressure) function, which is called 156x times per function call. Simply moving the constants out of the function already gave some gain. Then cutting the number `log` calculations in half also improved performance. However, the biggest improvement was removing the rounding - which imo is also something I would not expect from a function to do implicitly.

There are still a few more things that could be done (e.g. moving some of the inner functions out of the function). In the end the bottleneck will always be the `fsolve` - replacing it will be the biggest improvement before rewriting the entire function to natively work on np.arrays (no more `np.vectorize` needed).

I did try some `numba` jit-compiling but pure numpy always outperformed it by far.

I added tests for the array cases and shortened the tests bit by using `pytest.mark.parametrize`.

The behavior of `p_sat` and derivatives changed slightly, due to the rounding not being executed any longer. But at best that's more correct now.

This PR is a first step- I might look deeper into this at a later time, further optimizing it so it might be usable for larger rasters in the end.

Happy to hear your thought's on this!