### PR TITLE
fix invalid escape sequence that gave a syntax warning

### DIFF
--- a/pythermalcomfort/models/jos3.py
+++ b/pythermalcomfort/models/jos3.py
@@ -368,7 +368,7 @@ class JOS3:
         version_string = (
             __version__  # get the current version of pythermalcomfort package
         )
-        version_number_string = re.findall("\d+\.\d+\.\d+", version_string)[0]
+        version_number_string = re.findall(r"\d+\.\d+\.\d+", version_string)[0]
         self._version = version_number_string  # (ex. 'X.Y.Z')
 
         # Initialize basic attributes


### PR DESCRIPTION
Hey, that gave me a syntax warning. I checked the entire repo using...

```bash
flake8 pythermalcomfort --select W605
```
...but that was the only case.

One should probably use something like this instead...

```python
>>> from packaging.version import Version
>>> v = Version('1.2.3')
>>> v.major
1
>>> v.minor
2
>>> v.micro
3
>>> Version('1.2.3') > Version('1.2.2')
True
```