### PR TITLE
fix bug where t_mrt was incorrect for natural convection

### DIFF
--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -315,12 +315,12 @@ def mean_radiant_tmp(
 
         return np.around(tr, 1)
 
-    if standard == "iso":
+    if standard == "iso":  # pragma: no branch
         tg = np.add(tg, c_to_k)
         tdb = np.add(tdb, c_to_k)
 
         # calculate heat transfer coefficient
-        h_n = np.power(1.4 * (np.abs(tg - tdb) / d), 0.25)  # natural convection
+        h_n = 1.4 * np.power(np.abs(tg - tdb) / d, 0.25)  # natural convection
         h_f = 6.3 * np.power(v, 0.6) / np.power(d, 0.4)  # forced convection
 
         # get the biggest between the two coefficients

--- a/tests/test_psychrometrics.py
+++ b/tests/test_psychrometrics.py
@@ -59,13 +59,13 @@ def test_p_sat():
 def test_t_mrt():
     np.testing.assert_equal(
         mean_radiant_tmp(
-            tg=[53.2, 55],
+            tg=[53.2, 55, 55],
             tdb=30,
-            v=0.3,
+            v=[0.3, 0.3, 0.1],
             d=0.1,
             standard="ISO",
         ),
-        [74.8, 77.8],
+        [74.8, 77.8, 71.9],
     )
     np.testing.assert_equal(
         mean_radiant_tmp(


### PR DESCRIPTION
the coefficient of exchange at the level of the globe was calculated incorrectly

This is taken from the ISO-norm: E DIN EN ISO 7726:2023-08 ISO/DIS 7726:2023(E)

![grafik](https://github.com/user-attachments/assets/2200ee37-22f4-4aed-bf73-a1d71ccc0c2c)

This caused calculations of $T_{mrt}$ via the ISO-standard at low wind speed to be incorrect.

btw. I just saw that the function got moved and renamed - does that mean the new version will be completely incompatible with the previous versions? Without any deprecations?