### PR TITLE
speedup import time by caching numba vectorizes

### DIFF
--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -302,7 +302,7 @@ const_sw = math.exp(-1 / 10)
 
 
 @np.vectorize
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _phs_optimized(
     tdb,
     tr,

--- a/pythermalcomfort/models/pmv_ppd.py
+++ b/pythermalcomfort/models/pmv_ppd.py
@@ -243,6 +243,7 @@ def pmv_ppd(
             float64,
         )
     ],
+    cache=True,
 )
 def _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme):
     pa = rh * 10 * np.exp(16.6536 - 4030.183 / (tdb + 235))

--- a/pythermalcomfort/models/two_nodes.py
+++ b/pythermalcomfort/models/two_nodes.py
@@ -203,7 +203,7 @@ def two_nodes(
     return TwoNodes(**output)
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=True)
 def _two_nodes_optimized(
     tdb,
     tr,
@@ -549,6 +549,7 @@ def _two_nodes_optimized(
             float64,
         )
     ],
+    cache=True,
 )
 def _two_nodes_optimized_return_set(
     tdb,

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -153,6 +153,7 @@ def utci(
             float64,
         )
     ],
+    cache=True,
 )
 def _utci_optimized(tdb, v, delta_t_tr, pa):
     return (


### PR DESCRIPTION
currently the `models` module is very slow to import (~4000 ms)

I did some profiling and figured this was caused by `numba`-`vectorize` calls running on every import, compiling each function.

You can provide a `cache=True` argument to the decorator, so this is only done once, on the first time the module is imported and reused later on. This speeds up the import significantly about 4x!

See these simple benchmarks

Without cache:
```
....................
=================================== Results ====================================
Mean: 3706.179 ms
Standard deviation: 636.165 ms
Median: 3830.081 ms
```
With cache:
```
....................
=================================== Results ====================================
Mean: 922.372 ms
Standard deviation: 25.368 ms
Median: 915.538 ms
```

done using this:

```python
import os
import shutil
from statistics import mean, median, stdev
import subprocess
import time

CACHE = True

N = 20
timings = []
if CACHE is True:
    import pythermalcomfort.models

def main() -> int:
    for _ in range(N):
        print('.', end='', flush=True)
        start = time.monotonic()
        subprocess.run(['python', '-c', 'import pythermalcomfort.models'], env=os.environ)
        timings.append(time.monotonic() - start)
        if CACHE is False:
            files = os.listdir(os.environ['NUMBA_CACHE_DIR'])
            for f in files:
                shutil.rmtree(os.path.join(os.environ['NUMBA_CACHE_DIR'], f))

    print()
    print(' Results '.center(80, '='))
    print(f"Mean: {mean(timings) * 1000:.3f} ms")
    print(f"Standard deviation: {stdev(timings) * 1000:.3f} ms")
    print(f"Median: {median(timings) * 1000:.3f} ms")
    return 0


if __name__ == '__main__':
    raise SystemExit(main())
```