### PR TITLE
feat: add stress_category to hi_rothfusz (#168)

### DIFF
--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -234,6 +234,7 @@ class HI:
     """
 
     hi: Union[float, list[float]]
+    stress_category: Union[str, list[str]]
 
     def __getitem__(self, item):
         return getattr(self, item)

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -233,7 +233,7 @@ class HI:
         Heat Index, [°C] or [°F] depending on the units.
     """
 
-    hi: Union[float, list[float]]
+    hi: npt.ArrayLike
     stress_category: Union[str, list[str]]
 
     def __getitem__(self, item):

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -35,8 +35,8 @@ def heat_index_rothfusz(
 
         from pythermalcomfort.models import heat_index_rothfusz
 
-        result = heat_index_rothfusz(tdb=25, rh=50)
-        print(result.hi)    # 29.7
+        result = heat_index_rothfusz(tdb=29, rh=50)
+        print(result.hi)  # 29.7
         print(result.stress_category)  # "caution"
     """
     # Validate inputs using the HeatIndexInputs class
@@ -68,6 +68,6 @@ def heat_index_rothfusz(
     }
 
     if round_output:
-        hi = np.around(hi, 1)
+        hi_valid = np.around(hi_valid, 1)
 
-    return HI(hi=hi_valid, stress_category=mapping(hi, heat_index_categories))
+    return HI(hi=hi_valid, stress_category=mapping(hi_valid, heat_index_categories))

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pythermalcomfort.classes_input import HIInputs
 from pythermalcomfort.classes_return import HI
+from pythermalcomfort.shared_functions import mapping
 
 
 def heat_index_rothfusz(
@@ -35,7 +36,8 @@ def heat_index_rothfusz(
         from pythermalcomfort.models import heat_index_rothfusz
 
         result = heat_index_rothfusz(tdb=25, rh=50)
-        print(result.hi)
+        print(result.hi)    # 29.7
+        print(result.stress_category)  # "caution"
     """
     # Validate inputs using the HeatIndexInputs class
     HIInputs(
@@ -52,7 +54,20 @@ def heat_index_rothfusz(
     hi += 2.211732 * 10**-3 * tdb**2 * rh + 7.2546 * 10**-4 * tdb * rh**2
     hi += -3.582 * 10**-6 * tdb**2 * rh**2
 
+    # heat index should only be calculated for temperatures above 27 °C
+    tdb_valid = np.where((tdb >= 27.0), tdb, np.nan)
+    all_valid = ~(np.isnan(tdb_valid))
+    hi_valid = np.where(all_valid, hi, np.nan)
+
+    heat_index_categories = {
+        27.0: "no risk",
+        32.0: "caution",
+        41.0: "extreme caution",
+        54.0: "danger",
+        1000.0: "extreme danger",
+    }
+
     if round_output:
         hi = np.around(hi, 1)
 
-    return HI(hi=hi)
+    return HI(hi=hi_valid, stress_category=mapping(hi, heat_index_categories))

--- a/tests/test_heat_index_rothfusz.py
+++ b/tests/test_heat_index_rothfusz.py
@@ -1,5 +1,7 @@
 from pythermalcomfort.models import heat_index_rothfusz
 from tests.conftest import Urls, retrieve_reference_table, validate_result
+import numpy as np
+import pytest
 
 
 def test_heat_index(get_test_url, retrieve_data):
@@ -14,3 +16,35 @@ def test_heat_index(get_test_url, retrieve_data):
         result = heat_index_rothfusz(**inputs)
 
         validate_result(result, outputs, tolerance)
+
+
+def test_single_input_caution():
+    result = heat_index_rothfusz(tdb=29, rh=50, round_output=True)
+    assert result.hi.shape == ()  # zero-dim ndarray
+    assert result.hi.item() == pytest.approx(29.7, rel=1e-3)
+    assert result.stress_category == "caution"
+
+
+def test_below_threshold_produces_nan():
+    result = heat_index_rothfusz(tdb=25, rh=80)
+    assert np.isnan(result.hi).item()
+    assert isinstance(result.stress_category, np.str_)
+
+
+def test_vector_input_no_rounding():
+    tdb = [30.0, 20.0, 28.5]
+    rh = [70.0, 90.0, 50.0]
+    result = heat_index_rothfusz(tdb=tdb, rh=rh, round_output=False)
+    hi = result.hi
+    # Shape matches inputs
+    assert hi.shape == (3,)
+    # First element has multiple decimals and matches expected formula
+    assert hi[0] == pytest.approx(35.33, rel=1e-2)
+    # Second element below threshold ⇒ NaN
+    assert np.isnan(hi[1])
+    # Third element above threshold ⇒ finite number
+    assert np.isfinite(hi[2])
+    # Stress categories array matches hi length
+    assert isinstance(result.stress_category, np.ndarray)
+    assert result.stress_category.shape == (3,)
+    assert result.stress_category[0] == "extreme caution"

--- a/tests/test_heat_index_rothfusz.py
+++ b/tests/test_heat_index_rothfusz.py
@@ -1,7 +1,8 @@
-from pythermalcomfort.models import heat_index_rothfusz
-from tests.conftest import Urls, retrieve_reference_table, validate_result
 import numpy as np
 import pytest
+
+from pythermalcomfort.models import heat_index_rothfusz
+from tests.conftest import Urls, retrieve_reference_table, validate_result
 
 
 def test_heat_index(get_test_url, retrieve_data):


### PR DESCRIPTION
As requested in #168, I implemented to following:

* added stress_category mapping to heat_index_rothfusz.py, solution is based similar implementation for utci.py
* modified HI return class to accomodate stress_category output

As discussed, and different to an earlier version, I ignored the units.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The heat index calculation now provides a "stress category" label alongside the heat index value to help interpret results.
- **Bug Fixes**
  - Heat index is now only calculated for temperatures of 27°C or higher; values below this threshold return NaN.
- **Tests**
  - Expanded test coverage to include checks for scalar, threshold, and vectorized inputs, as well as validation of the new "stress category" output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->