### PR TITLE
Add work capacity metrics

### DIFF
--- a/docs/documentation/models.rst
+++ b/docs/documentation/models.rst
@@ -182,7 +182,7 @@ The Predicted Mean Vote (PMV) is an index that aims to predict the mean value of
 It was developed by Fanger [fanger1970]_.
 
 The PMV is designed to predict the average thermal sensation of a large group of people exposed to the same environment [ISO_7730_2005]_.
-It calculates the heat balance of a typical occupant and relates their thermal gains or losses to their predicted mean thermal sensation [ASHRAE_55_2023]_.
+It calculates the heat balance of a typical occupant and relates their thermal gains or capacityes to their predicted mean thermal sensation [ASHRAE_55_2023]_.
 
 The PMV can be used to check if a thermal environment meets comfort criteria and to establish requirements for different levels of acceptability.
 The PMV model is applicable to healthy men and women exposed to indoor environments where thermal comfort is desirable, but moderate deviations from thermal comfort occur, in the design of new environments or the assessment of existing ones.
@@ -325,3 +325,12 @@ Wind chill temperature
 .. autoclass:: pythermalcomfort.classes_return.WCT
     :members:
 
+Work capacity
+---------
+
+.. autofunction:: pythermalcomfort.models.work_capacity.workcapacity_dunne
+
+.. autofunction:: pythermalcomfort.models.work_capacity.workcapacity_hothaps
+
+.. autoclass:: pythermalcomfort.classes_return.WorkCapacity
+    :members:

--- a/docs/documentation/models.rst
+++ b/docs/documentation/models.rst
@@ -332,5 +332,8 @@ Work capacity
 
 .. autofunction:: pythermalcomfort.models.work_capacity.workcapacity_hothaps
 
+.. autofunction:: pythermalcomfort.models.work_capacity.workcapacity_iso
+
+.. autofunction:: pythermalcomfort.models.work_capacity.workcapacity_niosh
 .. autoclass:: pythermalcomfort.classes_return.WorkCapacity
     :members:

--- a/docs/documentation/models.rst
+++ b/docs/documentation/models.rst
@@ -182,7 +182,7 @@ The Predicted Mean Vote (PMV) is an index that aims to predict the mean value of
 It was developed by Fanger [fanger1970]_.
 
 The PMV is designed to predict the average thermal sensation of a large group of people exposed to the same environment [ISO_7730_2005]_.
-It calculates the heat balance of a typical occupant and relates their thermal gains or capacityes to their predicted mean thermal sensation [ASHRAE_55_2023]_.
+It calculates the heat balance of a typical occupant and relates their thermal gains or losses to their predicted mean thermal sensation [ASHRAE_55_2023]_.
 
 The PMV can be used to check if a thermal environment meets comfort criteria and to establish requirements for different levels of acceptability.
 The PMV model is applicable to healthy men and women exposed to indoor environments where thermal comfort is desirable, but moderate deviations from thermal comfort occur, in the design of new environments or the assessment of existing ones.

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -52,6 +52,7 @@ class BaseInputs:
     max_skin_blood_flow: Union[float, int, np.ndarray, list] = field(default=80)
     max_sweating: Union[float, int, np.ndarray, list] = field(default=500)
     w_max: Union[float, int, np.ndarray, list] = field(default=None)
+    wbgt: Union[float, int, np.ndarray, list] = field(default=None)
 
     def __post_init__(self):
         def is_pandas_series(obj):
@@ -216,6 +217,9 @@ class BaseInputs:
         if self.w_max is not None:
             self.w_max = convert_series_to_list(self.w_max)
             validate_type(self.w_max, "w_max", (float, int, np.ndarray, list))
+        if self.wbgt is not None:
+            self.wbgt = convert_series_to_list(self.wbgt)
+            validate_type(self.wbgt, "wbgt", (float, int, np.ndarray, list))
 
 
 @dataclass
@@ -850,4 +854,15 @@ class WCTInputs(BaseInputs):
             tdb=tdb,
             v=v,
             round_output=round_output,
+        )
+
+@dataclass
+class WorkCapacityInputs(BaseInputs):
+    def __init__(
+        self,
+        wbgt,
+    ):
+        # Initialize with only required fields, setting others to None
+        super().__init__(
+            wbgt=wbgt,
         )

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -53,6 +53,7 @@ class BaseInputs:
     max_sweating: Union[float, int, np.ndarray, list] = field(default=500)
     w_max: Union[float, int, np.ndarray, list] = field(default=None)
     wbgt: Union[float, int, np.ndarray, list] = field(default=None)
+    intensity: Union[str, np.ndarray, list] = field(default=None)
 
     def __post_init__(self):
         def is_pandas_series(obj):
@@ -856,13 +857,30 @@ class WCTInputs(BaseInputs):
             round_output=round_output,
         )
 
+
 @dataclass
-class WorkCapacityInputs(BaseInputs):
+class WorkCapacityHothapsInputs(BaseInputs):
     def __init__(
         self,
         wbgt,
+        intensity,
     ):
         # Initialize with only required fields, setting others to None
         super().__init__(
             wbgt=wbgt,
+            intensity=intensity,
+        )
+
+
+@dataclass
+class WorkCapacityStandardsInputs(BaseInputs):
+    def __init__(
+        self,
+        wbgt,
+        met,
+    ):
+        # Initialize with only required fields, setting others to None
+        super().__init__(
+            wbgt=wbgt,
+            met=met,
         )

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -638,6 +638,22 @@ class WCT:
 
 
 @dataclass(frozen=True)
+class WorkCapacity:
+    """Dataclass to represent work loss.
+
+    Attributes
+    ----------
+    capacity : float or list of floats
+        Work capacity affected by heat.
+    """
+
+    capacity: Union[float, npt.ArrayLike]
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+
+@dataclass(frozen=True)
 class JOS3BodyParts:
     """Dataclass to represent the body parts in the JOS3 model. It is very important to
     keep the order of the attributes as they are defined in the dataclass ['head',

--- a/pythermalcomfort/models/work_capacity.py
+++ b/pythermalcomfort/models/work_capacity.py
@@ -2,12 +2,14 @@ from typing import Union
 
 import numpy as np
 
+from pythermalcomfort.classes_input import WorkCapacityInputs
 from pythermalcomfort.classes_return import WorkCapacity
 
 
-def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str):
+
+def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str) -> WorkCapacity:
     """
-    Estimate work capacity due to heat based on Dunne et al
+    Estimate work capacity due to heat based ISO standards as described by Dunne et al
 
     Estimates the amount of work that will be done at a given WBGT and
     intensity of work as a percent. 100% means work is unaffected by heat. 0%
@@ -17,8 +19,9 @@ def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str):
     Dunne JP, Stouffer RJ, John JG. Reductions in labour capacity from heat
     stress under climate warming. Nature Climate Change. 2013 Jun;3(6):563–6.
 
-    Heavy intensity work is sometimes labelled as 400 W, medium 300 W, light 200
-    W, but this is only nominal.
+    Heavy intensity work is sometimes labelled as 400 W, but this is only
+    nominal. Medium work is assumed to be half as much as heavy intensity, and
+    light half as much as medium.
 
     Parameters
     ----------
@@ -37,6 +40,9 @@ def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str):
         `result.capacity`.
 
     """
+    #Validate inputs
+    WorkCapacityInputs(wbgt=wbgt) 
+
     wbgt = np.array(wbgt)
     capacity = np.clip((100 - (25 * (np.maximum(0, wbgt - 25)) ** (2 / 3))), 0, 100)
     if intensity == "heavy":
@@ -51,13 +57,15 @@ def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str):
     return WorkCapacity(capacity=capacity)
 
 
-def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str):
+def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> WorkCapacity:
     """
     Estimate work capacity due to heat based on Kjellstrom et al.
 
     Estimates the amount of work that will be done at a given WBGT and
     intensity of work as a percent. 100% means work is unaffected by heat. 0%
-    means no work is done.
+    means no work is done. Note that in this version the functions do not reach
+    0% as it is assumed that it is always possible to work in short bursts for
+    10% of the time.
 
     Note that for this function "the empirical evidence is from studies in
     heavyly distinct locations, including a gold mine (Wyndham, 1969), 124 rice
@@ -70,8 +78,11 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str):
     Heavy intensity work is sometimes labelled as 400 W, medium 300 W, light 200
     W, but this is only nominal.
 
-    Sometimes the maximum capacity of work is assumed to be 95% rather than 100%,
-    but we do not apply that here.
+    The correction citation is: Bröde P, Fiala D, Lemke B, Kjellstrom T.
+    Estimated work ability in warm outdoor environments depends on the chosen
+    heat stress assessment metric. International Journal of Biometeorology.
+    2018 Mar;62(3):331–45. 
+
 
     The relevant definitions of the functions can be found most clearly in:
     Orlov A, Sillmann J, Aunan K, Kjellstrom T, Aaheim A. Economic costs of
@@ -79,11 +90,10 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str):
     Environmental Change [Internet]. 2020 Jul;63. Available from:
     https://doi.org/10.1016/j.gloenvcha.2020.102087
 
-    But often people cite:
-    See Kjellstrom, T., Freyberg, C., Lemke, B. et al. Estimating population
-    heat exposure and impacts on working people in conjunction with climate
-    change. Int J Biometeorol 62, 291–306 (2018).
-    https://doi.org/10.1007/s00484-017-1407-0
+    For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
+    N, Costa H, Mavrogianni A. Upholding labour productivity under climate
+    change: an assessment of adaptation options. Climate Policy. 2019
+    Mar;19(3):367–85. 
 
     Parameters
     ----------
@@ -103,16 +113,121 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str):
 
 
     """
+    #Validate inputs
+    WorkCapacityInputs(wbgt=wbgt) 
+
     wbgt = np.array(wbgt)
     if intensity == "heavy":
-        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 30.94) ** 16.64)))
+        capacity = 100 * (0.1 + (0.9 / (1 + (wbgt / 30.94) ** 16.64)))
     elif intensity == "med":
-        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 32.93) ** 17.81)))
+        capacity = 100 * (0.1 + (0.9 / (1 + (wbgt / 32.93) ** 17.81)))
     elif intensity == "light":
-        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 34.64) ** 22.72)))
+        capacity = 100 * (0.1 + (0.9 / (1 + (wbgt / 34.64) ** 22.72)))
     else:
         raise ValueError("intensity should = heavy, med, or light")
 
+    capacity = np.clip(capacity, 0, 100)
+
+    return WorkCapacity(capacity=capacity)
+
+def workcapacity_niosh(wbgt: Union[float, list[float]], M: Union[float,list[float]]) -> WorkCapacity:
+    """
+    Estimate work capacity due to heat based on NIOSH standards as described by Brode et al
+
+    Estimates the amount of work that will be done at a given WBGT and
+    intensity of work as a percent. 100% means work is unaffected by heat. 0%
+    means no work is done.
+
+    The function definitions / parameters can be found in: 1. Bröde P, Fiala D,
+    Lemke B, Kjellstrom T. Estimated work ability in warm outdoor environments
+    depends on the chosen heat stress assessment metric. International Journal
+    of Biometeorology. 2018 Mar;62(3):331–45. 
+
+    For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
+    N, Costa H, Mavrogianni A. Upholding labour productivity under climate
+    change: an assessment of adaptation options. Climate Policy. 2019
+    Mar;19(3):367–85. 
+
+    Parameters
+    ----------
+    wbgt : float or list of floats
+        Wet bulb globe temperature, [°C].
+    M : float or list of floats
+        Metabolic heat production in Watts
+
+    Returns
+    -------
+    WorkCapacity
+        A dataclass containing the work capacity. See
+        :py:class:`~pythermalcomfort.classes_return.WorkCapacity` for more details. To access the
+        `capacity` value, use the `capacity` attribute of the returned `WorkCapacity` instance, e.g.,
+        `result.capacity`.
+
+
+    """
+    #Validate inputs
+    WorkCapacityInputs(wbgt=wbgt) 
+
+    wbgt = np.array(wbgt)
+    M = np.array(M)
+    if (M<0).any() or (M>2500).any():
+        raise ValueError("Metabolic rate out of plausible range")
+    Mrest = 117 # assumed resting metabolic rate
+
+    wbgt_lim = 56.7 - 11.5*np.log10(M)
+    wbgt_lim_rest = 56.7 - 11.5*np.log10(Mrest)
+    capacity = ((wbgt_lim_rest-wbgt)/(wbgt_lim_rest-wbgt_lim))*100
+    capacity = np.clip(capacity, 0, 100)
+
+    return WorkCapacity(capacity=capacity)
+
+def workcapacity_iso(wbgt: Union[float, list[float]], M: Union[float,list[float]]) -> WorkCapacity:
+    """
+    Estimate work capacity due to heat based on ISO standards as described by Brode et al
+
+    Estimates the amount of work that will be done at a given WBGT and
+    intensity of work as a percent. 100% means work is unaffected by heat. 0%
+    means no work is done.
+
+    The function definitions / parameters can be found in: 1. Bröde P, Fiala D,
+    Lemke B, Kjellstrom T. Estimated work ability in warm outdoor environments
+    depends on the chosen heat stress assessment metric. International Journal
+    of Biometeorology. 2018 Mar;62(3):331–45. 
+
+    For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
+    N, Costa H, Mavrogianni A. Upholding labour productivity under climate
+    change: an assessment of adaptation options. Climate Policy. 2019
+    Mar;19(3):367–85. 
+
+    Parameters
+    ----------
+    wbgt : float or list of floats
+        Wet bulb globe temperature, [°C].
+    M : float or list of floats
+        Metabolic heat production in Watts
+
+    Returns
+    -------
+    WorkCapacity
+        A dataclass containing the work capacity. See
+        :py:class:`~pythermalcomfort.classes_return.WorkCapacity` for more details. To access the
+        `capacity` value, use the `capacity` attribute of the returned `WorkCapacity` instance, e.g.,
+        `result.capacity`.
+
+
+    """
+    #Validate inputs
+    WorkCapacityInputs(wbgt=wbgt) 
+
+    wbgt = np.array(wbgt)
+    M = np.array(M)
+    if (M<0).any() or (M>2500).any():
+        raise ValueError("Metabolic rate out of plausible range")
+    Mrest = 117 # assumed resting metabolic rate
+
+    wbgt_lim = 34.9-M/46
+    wbgt_lim_rest = 34.9-Mrest/46
+    capacity = ((wbgt_lim_rest-wbgt)/(wbgt_lim_rest-wbgt_lim))*100
     capacity = np.clip(capacity, 0, 100)
 
     return WorkCapacity(capacity=capacity)

--- a/pythermalcomfort/models/work_capacity.py
+++ b/pythermalcomfort/models/work_capacity.py
@@ -1,0 +1,118 @@
+from typing import Union
+
+import numpy as np
+
+from pythermalcomfort.classes_return import WorkCapacity
+
+
+def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str):
+    """
+    Estimate work capacity due to heat based on Dunne et al
+
+    Estimates the amount of work that will be done at a given WBGT and
+    intensity of work as a percent. 100% means work is unaffected by heat. 0%
+    means no work is done.
+
+    This is based upon NIOSH safety standards. See:
+    Dunne JP, Stouffer RJ, John JG. Reductions in labour capacity from heat
+    stress under climate warming. Nature Climate Change. 2013 Jun;3(6):563–6.
+
+    Heavy intensity work is sometimes labelled as 400 W, medium 300 W, light 200
+    W, but this is only nominal.
+
+    Parameters
+    ----------
+    wbgt : float or list of floats
+        Wet bulb globe temperature, [°C].
+    intensity : str
+        Which work intensity to use for the calculation, choice of "heavy",
+        "med" or "light".
+
+    Returns
+    -------
+    WorkCapacity
+        A dataclass containing the work capacity. See
+        :py:class:`~pythermalcomfort.classes_return.WorkCapacity` for more details. To access the
+        `capacity` value, use the `capacity` attribute of the returned `WorkCapacity` instance, e.g.,
+        `result.capacity`.
+
+    """
+    wbgt = np.array(wbgt)
+    capacity = np.clip((100 - (25 * (np.maximum(0, wbgt - 25)) ** (2 / 3))), 0, 100)
+    if intensity == "heavy":
+        pass
+    elif intensity == "med":
+        capacity = np.clip(capacity * 2, 0, 100)
+    elif intensity == "light":
+        capacity = np.clip(capacity * 4, 0, 100)
+    else:
+        raise ValueError("intensity should = heavy, med, or light")
+
+    return WorkCapacity(capacity=capacity)
+
+
+def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str):
+    """
+    Estimate work capacity due to heat based on Kjellstrom et al.
+
+    Estimates the amount of work that will be done at a given WBGT and
+    intensity of work as a percent. 100% means work is unaffected by heat. 0%
+    means no work is done.
+
+    Note that for this function "the empirical evidence is from studies in
+    heavyly distinct locations, including a gold mine (Wyndham, 1969), 124 rice
+    harvesters in West Bengal in India (Sahu et al., 2013), and six women
+    observed in a climatic chamber (Nag and Nag, 1992)."
+    (https://adaptecca.es/sites/default/files/documentos/2018_jrc_pesetaiii_impact_labour_productivity.pdf).
+    The shape of the function is just an assumption, and the fit of the
+    sigmoid to the data it is analysing is not especially good.
+
+    Heavy intensity work is sometimes labelled as 400 W, medium 300 W, light 200
+    W, but this is only nominal.
+
+    Sometimes the maximum capacity of work is assumed to be 95% rather than 100%,
+    but we do not apply that here.
+
+    The relevant definitions of the functions can be found most clearly in:
+    Orlov A, Sillmann J, Aunan K, Kjellstrom T, Aaheim A. Economic costs of
+    heat-induced reductions in worker productivity due to global warming. Global
+    Environmental Change [Internet]. 2020 Jul;63. Available from:
+    https://doi.org/10.1016/j.gloenvcha.2020.102087
+
+    But often people cite:
+    See Kjellstrom, T., Freyberg, C., Lemke, B. et al. Estimating population
+    heat exposure and impacts on working people in conjunction with climate
+    change. Int J Biometeorol 62, 291–306 (2018).
+    https://doi.org/10.1007/s00484-017-1407-0
+
+    Parameters
+    ----------
+    wbgt : float or list of floats
+        Wet bulb globe temperature, [°C].
+    intensity : str
+        Which work intensity to use for the calculation, choice of "heavy",
+        "med" or "light".
+
+    Returns
+    -------
+    WorkCapacity
+        A dataclass containing the work capacity. See
+        :py:class:`~pythermalcomfort.classes_return.WorkCapacity` for more details. To access the
+        `capacity` value, use the `capacity` attribute of the returned `WorkCapacity` instance, e.g.,
+        `result.capacity`.
+
+
+    """
+    wbgt = np.array(wbgt)
+    if intensity == "heavy":
+        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 30.94) ** 16.64)))
+    elif intensity == "med":
+        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 32.93) ** 17.81)))
+    elif intensity == "light":
+        capacity = 100 - 100 * (0.1 + (0.9 / (1 + (wbgt / 34.64) ** 22.72)))
+    else:
+        raise ValueError("intensity should = heavy, med, or light")
+
+    capacity = np.clip(capacity, 0, 100)
+
+    return WorkCapacity(capacity=capacity)

--- a/pythermalcomfort/models/work_capacity.py
+++ b/pythermalcomfort/models/work_capacity.py
@@ -2,9 +2,11 @@ from typing import Union
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WorkCapacityInputs
+from pythermalcomfort.classes_input import (
+    WorkCapacityHothapsInputs,
+    WorkCapacityStandardsInputs,
+)
 from pythermalcomfort.classes_return import WorkCapacity
-
 
 
 def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str) -> WorkCapacity:
@@ -40,8 +42,8 @@ def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str) -> WorkC
         `result.capacity`.
 
     """
-    #Validate inputs
-    WorkCapacityInputs(wbgt=wbgt) 
+    # Validate inputs
+    WorkCapacityHothapsInputs(wbgt=wbgt, intensity=intensity)
 
     wbgt = np.array(wbgt)
     capacity = np.clip((100 - (25 * (np.maximum(0, wbgt - 25)) ** (2 / 3))), 0, 100)
@@ -57,7 +59,9 @@ def workcapacity_dunne(wbgt: Union[float, list[float]], intensity: str) -> WorkC
     return WorkCapacity(capacity=capacity)
 
 
-def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> WorkCapacity:
+def workcapacity_hothaps(
+    wbgt: Union[float, list[float]], intensity: str
+) -> WorkCapacity:
     """
     Estimate work capacity due to heat based on Kjellstrom et al.
 
@@ -81,7 +85,7 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> Wor
     The correction citation is: Bröde P, Fiala D, Lemke B, Kjellstrom T.
     Estimated work ability in warm outdoor environments depends on the chosen
     heat stress assessment metric. International Journal of Biometeorology.
-    2018 Mar;62(3):331–45. 
+    2018 Mar;62(3):331–45.
 
 
     The relevant definitions of the functions can be found most clearly in:
@@ -93,7 +97,7 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> Wor
     For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
     N, Costa H, Mavrogianni A. Upholding labour productivity under climate
     change: an assessment of adaptation options. Climate Policy. 2019
-    Mar;19(3):367–85. 
+    Mar;19(3):367–85.
 
     Parameters
     ----------
@@ -113,8 +117,8 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> Wor
 
 
     """
-    #Validate inputs
-    WorkCapacityInputs(wbgt=wbgt) 
+    # Validate inputs
+    WorkCapacityHothapsInputs(wbgt=wbgt, intensity=intensity)
 
     wbgt = np.array(wbgt)
     if intensity == "heavy":
@@ -130,7 +134,10 @@ def workcapacity_hothaps(wbgt: Union[float, list[float]], intensity: str) -> Wor
 
     return WorkCapacity(capacity=capacity)
 
-def workcapacity_niosh(wbgt: Union[float, list[float]], M: Union[float,list[float]]) -> WorkCapacity:
+
+def workcapacity_niosh(
+    wbgt: Union[float, list[float]], M: Union[float, list[float]]
+) -> WorkCapacity:
     """
     Estimate work capacity due to heat based on NIOSH standards as described by Brode et al
 
@@ -141,12 +148,12 @@ def workcapacity_niosh(wbgt: Union[float, list[float]], M: Union[float,list[floa
     The function definitions / parameters can be found in: 1. Bröde P, Fiala D,
     Lemke B, Kjellstrom T. Estimated work ability in warm outdoor environments
     depends on the chosen heat stress assessment metric. International Journal
-    of Biometeorology. 2018 Mar;62(3):331–45. 
+    of Biometeorology. 2018 Mar;62(3):331–45.
 
     For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
     N, Costa H, Mavrogianni A. Upholding labour productivity under climate
     change: an assessment of adaptation options. Climate Policy. 2019
-    Mar;19(3):367–85. 
+    Mar;19(3):367–85.
 
     Parameters
     ----------
@@ -165,23 +172,26 @@ def workcapacity_niosh(wbgt: Union[float, list[float]], M: Union[float,list[floa
 
 
     """
-    #Validate inputs
-    WorkCapacityInputs(wbgt=wbgt) 
+    # Validate inputs
+    WorkCapacityStandardsInputs(wbgt=wbgt, met=M)
 
     wbgt = np.array(wbgt)
     M = np.array(M)
-    if (M<0).any() or (M>2500).any():
+    if (M < 0).any() or (M > 2500).any():
         raise ValueError("Metabolic rate out of plausible range")
-    Mrest = 117 # assumed resting metabolic rate
+    Mrest = 117  # assumed resting metabolic rate
 
-    wbgt_lim = 56.7 - 11.5*np.log10(M)
-    wbgt_lim_rest = 56.7 - 11.5*np.log10(Mrest)
-    capacity = ((wbgt_lim_rest-wbgt)/(wbgt_lim_rest-wbgt_lim))*100
+    wbgt_lim = 56.7 - 11.5 * np.log10(M)
+    wbgt_lim_rest = 56.7 - 11.5 * np.log10(Mrest)
+    capacity = ((wbgt_lim_rest - wbgt) / (wbgt_lim_rest - wbgt_lim)) * 100
     capacity = np.clip(capacity, 0, 100)
 
     return WorkCapacity(capacity=capacity)
 
-def workcapacity_iso(wbgt: Union[float, list[float]], M: Union[float,list[float]]) -> WorkCapacity:
+
+def workcapacity_iso(
+    wbgt: Union[float, list[float]], M: Union[float, list[float]]
+) -> WorkCapacity:
     """
     Estimate work capacity due to heat based on ISO standards as described by Brode et al
 
@@ -192,12 +202,12 @@ def workcapacity_iso(wbgt: Union[float, list[float]], M: Union[float,list[float]
     The function definitions / parameters can be found in: 1. Bröde P, Fiala D,
     Lemke B, Kjellstrom T. Estimated work ability in warm outdoor environments
     depends on the chosen heat stress assessment metric. International Journal
-    of Biometeorology. 2018 Mar;62(3):331–45. 
+    of Biometeorology. 2018 Mar;62(3):331–45.
 
     For a comparison of different functions see Fig 1 of Day E, Fankhauser S, Kingsmill
     N, Costa H, Mavrogianni A. Upholding labour productivity under climate
     change: an assessment of adaptation options. Climate Policy. 2019
-    Mar;19(3):367–85. 
+    Mar;19(3):367–85.
 
     Parameters
     ----------
@@ -216,18 +226,18 @@ def workcapacity_iso(wbgt: Union[float, list[float]], M: Union[float,list[float]
 
 
     """
-    #Validate inputs
-    WorkCapacityInputs(wbgt=wbgt) 
+    # Validate inputs
+    WorkCapacityStandardsInputs(wbgt=wbgt, met=M)
 
     wbgt = np.array(wbgt)
     M = np.array(M)
-    if (M<0).any() or (M>2500).any():
+    if (M < 0).any() or (M > 2500).any():
         raise ValueError("Metabolic rate out of plausible range")
-    Mrest = 117 # assumed resting metabolic rate
+    Mrest = 117  # assumed resting metabolic rate
 
-    wbgt_lim = 34.9-M/46
-    wbgt_lim_rest = 34.9-Mrest/46
-    capacity = ((wbgt_lim_rest-wbgt)/(wbgt_lim_rest-wbgt_lim))*100
+    wbgt_lim = 34.9 - M / 46
+    wbgt_lim_rest = 34.9 - Mrest / 46
+    capacity = ((wbgt_lim_rest - wbgt) / (wbgt_lim_rest - wbgt_lim)) * 100
     capacity = np.clip(capacity, 0, 100)
 
     return WorkCapacity(capacity=capacity)

--- a/tests/test_workcapacity.py
+++ b/tests/test_workcapacity.py
@@ -1,0 +1,35 @@
+import pytest
+
+from pythermalcomfort.models import work_capacity
+
+
+# Test incorrect intensity gives value error
+def test_workcapacity_dunne_invalid_intensity():
+    with pytest.raises(ValueError):
+        work_capacity.workcapacity_dunne(30, "foo")
+
+
+def test_workcapacity_hothaps_invalid_intensity():
+    with pytest.raises(ValueError):
+        work_capacity.workcapacity_hothaps(30, "foo")
+
+
+def test_workcapacity_iso_invalid_intensity():
+    with pytest.raises(TypeError):
+        work_capacity.workcapacity_iso(30, "foo")
+
+
+def test_workcapacity_niosh_invalid_intensity():
+    with pytest.raises(TypeError):
+        work_capacity.workcapacity_niosh(30, "foo")
+
+
+#  Calculate with wbgt set to None
+def test_workcapacity_dunne_wbgt_set_to_none():
+    with pytest.raises(TypeError):
+        work_capacity.workcapacity_dunne(None, "heavy")
+
+
+def test_workcapacity_hothaps_wbgt_set_to_none():
+    with pytest.raises(TypeError):
+        work_capacity.workcapacity_hothaps(None, "heavy")


### PR DESCRIPTION
Aims to address issue #176 @FedericoTartarini 

I have added functions for estimating labour capacity loss. I have added a few references in the docstrings so people can trace the sources of the numbers. I have added some input validation, tests, and added it to the list of models.

Here is a plot of the functions I added:
![workcapacity](https://github.com/user-attachments/assets/feae8fb2-23df-42fd-8741-808dce21d455)

It passed `tox -e py312` and `tox -e docs`.
You might want to check I implemented the input and output classes in a style consistent with the style of the repo as this is my first time contributing to this project.