### PR TITLE
enhance validate_type function to handle numpy scalars

### DIFF
--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -374,6 +374,8 @@ def mean_radiant_tmp(
 
 def validate_type(value, name: str, allowed_types: tuple):
     """Validate the type of a value against allowed types."""
+    if isinstance(value, np.generic):
+        value = value.item()
     if not isinstance(value, allowed_types):
         raise TypeError(f"{name} must be one of the following types: {allowed_types}.")
 


### PR DESCRIPTION
This PR contains a simple modification to `validate_type` so that it handles numpy scalars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type validation to ensure numeric values convert properly and are handled consistently.
- **Tests**
  - Added tests to verify correct behavior for supported numeric types and proper error messaging for unsupported types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->