### PR TITLE
Replace np.array() with np.asarray() for better memory efficiency

### DIFF
--- a/examples/calc_jos3.py
+++ b/examples/calc_jos3.py
@@ -78,7 +78,7 @@ def detailed_simulation():
     model.tdb = 28  # Air temperature [°C]
     model.tr = 30  # Mean radiant temperature [°C]
     model.rh = 40  # Relative humidity [%]
-    model.v = np.array(  # Air velocity [m/s]
+    model.v = np.asarray(  # Air velocity [m/s]
         [
             0.2,  # head
             0.4,  # neck
@@ -235,7 +235,7 @@ def validation_simulation():
     def sim_stolwijk_hardy(models, tolist, rhlist):
         result = []
         for model in models:
-            model.icl = np.array(
+            model.icl = np.asarray(
                 [
                     0,
                     0,

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -796,7 +796,7 @@ class JOS3BodyParts(AutoStrMixin):
 
 
 def get_attribute_values(cls):
-    return np.array([getattr(cls, field.name) for field in fields(cls)])
+    return np.asarray([getattr(cls, field.name) for field in fields(cls)])
 
 
 @dataclass(frozen=True, repr=False)

--- a/pythermalcomfort/jos3_functions/construction.py
+++ b/pythermalcomfort/jos3_functions/construction.py
@@ -83,7 +83,7 @@ def to_array_body_parts(inp) -> np.ndarray:
     if isinstance(inp, int | float):
         return np.full(Default.num_body_parts, inp)
     if isinstance(inp, dict):
-        return np.array([inp[key] for key in JOS3BodyParts.get_attribute_names()])
+        return np.asarray([inp[key] for key in JOS3BodyParts.get_attribute_names()])
     if isinstance(inp, list | np.ndarray):
         inp = np.asarray(inp)
         if inp.shape == (Default.num_body_parts,):
@@ -296,7 +296,7 @@ def conductance(
 
     """
     if fat < 12.5:
-        cdt_cr_sk = np.array(
+        cdt_cr_sk = np.asarray(
             [
                 1.341,
                 0.930,
@@ -318,7 +318,7 @@ def conductance(
             ],
         )
     elif fat < 17.5:
-        cdt_cr_sk = np.array(
+        cdt_cr_sk = np.asarray(
             [
                 1.311,
                 0.909,
@@ -340,7 +340,7 @@ def conductance(
             ],
         )
     elif fat < 22.5:
-        cdt_cr_sk = np.array(
+        cdt_cr_sk = np.asarray(
             [
                 1.282,
                 0.889,
@@ -362,7 +362,7 @@ def conductance(
             ],
         )
     elif fat < 27.5:
-        cdt_cr_sk = np.array(
+        cdt_cr_sk = np.asarray(
             [
                 1.255,
                 0.870,
@@ -384,7 +384,7 @@ def conductance(
             ],
         )
     else:  # fat >= 27.5
-        cdt_cr_sk = np.array(
+        cdt_cr_sk = np.asarray(
             [
                 1.227,
                 0.852,
@@ -424,7 +424,7 @@ def conductance(
     # stolwijk's core radius.
     # The heat transfer coefficient of the core is assumed as the Michel's
     # counter-flow model 0.66816 [W/(m･K)].
-    cdt_ves_cr = np.array(
+    cdt_ves_cr = np.asarray(
         [
             0,
             0,
@@ -446,7 +446,7 @@ def conductance(
         ],
     )
     # superficial vein to skin
-    cdt_sfv_sk = np.array(
+    cdt_sfv_sk = np.asarray(
         [
             0,
             0,
@@ -471,7 +471,7 @@ def conductance(
     # art to vein (counter-flow) [W/K]
     # The data has been derived Mitchell's model.
     # The values = 15.869 [W/(m･K)] * the segment length [m]
-    cdt_art_vein = np.array(
+    cdt_art_vein = np.asarray(
         [
             0,
             0,
@@ -580,7 +580,7 @@ def capacity(
     # Define capacities [Wh/K]
 
     # artery [Wh/K]
-    cap_art = np.array(
+    cap_art = np.asarray(
         [
             0.096,
             0.025,
@@ -603,7 +603,7 @@ def capacity(
     )
 
     # vein [Wh/K]
-    cap_vein = np.array(
+    cap_vein = np.asarray(
         [
             0.321,
             0.085,
@@ -626,7 +626,7 @@ def capacity(
     )
 
     # superficial vein [Wh/K]
-    cap_sfv = np.array(
+    cap_sfv = np.asarray(
         [
             0,
             0,
@@ -652,7 +652,7 @@ def capacity(
     cap_cb = 1.999
 
     # core [Wh/K]
-    cap_cr = np.array(
+    cap_cr = np.asarray(
         [
             1.7229,
             0.564,
@@ -675,7 +675,7 @@ def capacity(
     )
 
     # muscle [Wh/K]
-    cap_ms = np.array(
+    cap_ms = np.asarray(
         [
             0.305,
             0.0,
@@ -698,7 +698,7 @@ def capacity(
     )
 
     # fat [Wh/K]
-    cap_fat = np.array(
+    cap_fat = np.asarray(
         [
             0.203,
             0.0,
@@ -721,7 +721,7 @@ def capacity(
     )
 
     # skin [Wh/K]
-    cap_sk = np.array(
+    cap_sk = np.asarray(
         [
             0.1885,
             0.058,

--- a/pythermalcomfort/jos3_functions/parameters.py
+++ b/pythermalcomfort/jos3_functions/parameters.py
@@ -41,7 +41,7 @@ class Default:
     posture: str = Postures.standing.value
     bmr_equation: str = "harris-benedict"
     bsa_equation: str = BodySurfaceAreaEquations.dubois.value
-    local_bsa: ClassVar[list[float]] = np.array(  # body surface area [m2]
+    local_bsa: ClassVar[list[float]] = np.asarray(  # body surface area [m2]
         [
             0.110,
             0.029,

--- a/pythermalcomfort/jos3_functions/thermoregulation.py
+++ b/pythermalcomfort/jos3_functions/thermoregulation.py
@@ -38,7 +38,7 @@ def natural_convection(posture: str, tdb: float, t_skin: float) -> np.ndarray:
     """
     if posture.lower() == Postures.standing.value:
         # Ichihara et al., 1997, https://doi.org/10.3130/aija.62.45_5
-        hc_natural = np.array(
+        hc_natural = np.asarray(
             [
                 4.48,
                 4.48,
@@ -61,7 +61,7 @@ def natural_convection(posture: str, tdb: float, t_skin: float) -> np.ndarray:
         )
     elif posture.lower() in [Postures.sitting.value, Postures.sedentary.value]:
         # Ichihara et al., 1997, https://doi.org/10.3130/aija.62.45_5
-        hc_natural = np.array(
+        hc_natural = np.asarray(
             [
                 4.75,
                 4.75,
@@ -85,7 +85,7 @@ def natural_convection(posture: str, tdb: float, t_skin: float) -> np.ndarray:
     elif posture.lower() in [Postures.lying.value, Postures.supine.value]:
         # Kurazumi et al., 2008, https://doi.org/10.20718/jjpa.13.1_17
         # The values are applied under cold environment.
-        hc_a = np.array(
+        hc_a = np.asarray(
             [
                 1.105,
                 1.105,
@@ -106,7 +106,7 @@ def natural_convection(posture: str, tdb: float, t_skin: float) -> np.ndarray:
                 0.200,
             ],
         )
-        hc_b = np.array(
+        hc_b = np.asarray(
             [
                 0.345,
                 0.345,
@@ -157,7 +157,7 @@ def forced_convection(v: float) -> np.ndarray:
         Forced convection heat transfer coefficient body segments.
 
     """
-    hc_a = np.array(
+    hc_a = np.asarray(
         [
             15.0,
             15.0,
@@ -178,7 +178,7 @@ def forced_convection(v: float) -> np.ndarray:
             15.1,
         ],
     )
-    hc_b = np.array(
+    hc_b = np.asarray(
         [
             0.62,
             0.62,
@@ -256,7 +256,7 @@ def rad_coef(posture: str) -> np.ndarray:
     """
     if posture.lower() == Postures.standing.value:
         # Ichihara et al., 1997, https://doi.org/10.3130/aija.62.45_5
-        hr = np.array(
+        hr = np.asarray(
             [
                 4.89,
                 4.89,
@@ -279,7 +279,7 @@ def rad_coef(posture: str) -> np.ndarray:
         )
     elif posture.lower() in [Postures.sitting.value, Postures.sedentary.value]:
         # Ichihara et al., 1997, https://doi.org/10.3130/aija.62.45_5
-        hr = np.array(
+        hr = np.asarray(
             [
                 4.96,
                 4.96,
@@ -302,7 +302,7 @@ def rad_coef(posture: str) -> np.ndarray:
         )
     elif posture.lower() in [Postures.lying.value, Postures.supine.value]:
         # Kurazumi et al., 2008, https://doi.org/10.20718/jjpa.13.1_17
-        hr = np.array(
+        hr = np.asarray(
             [
                 5.475,
                 5.475,
@@ -449,7 +449,7 @@ def dry_r(hc, hr, clo):
         If any of the input parameters are negative.
 
     """
-    if (np.array(hc) < 0).any() or (np.array(hr) < 0).any():
+    if (np.asarray(hc) < 0).any() or (np.asarray(hr) < 0).any():
         raise ValueError("Input parameters hc and hr must be non-negative.")
 
     fcl = clo_area_factor(clo)
@@ -490,7 +490,7 @@ def wet_r(
         If any of the input parameters are negative.
 
     """
-    if (np.array(hc) < 0).any():
+    if (np.asarray(hc) < 0).any():
         raise ValueError("Input parameters hc must be non-negative.")
 
     fcl = clo_area_factor(clo)
@@ -515,10 +515,10 @@ def error_signals(err_sk=0.0):
         Warm signal (WRMS) [°C] and Cold signal (CLDS) [°C].
 
     """
-    err_sk = np.array(err_sk, dtype=float)
+    err_sk = np.asarray(err_sk, dtype=float)
 
     # SKINR (Distribution coefficients of thermal receptor) [-]
-    receptor = np.array(
+    receptor = np.asarray(
         [
             0.0549,
             0.0146,
@@ -632,7 +632,7 @@ def evaporation(
     e_max = np.where(e_max == 0, 0.001, e_max)
 
     # SKINS
-    skin_sweat = np.array(
+    skin_sweat = np.asarray(
         [
             0.064,
             0.017,
@@ -662,7 +662,7 @@ def evaporation(
     if age < 60:
         sd_sweat = np.ones(Default.num_body_parts)
     else:  # age >= 60
-        sd_sweat = np.array(
+        sd_sweat = np.asarray(
             [
                 0.69,
                 0.69,
@@ -726,7 +726,7 @@ def skin_blood_flow(
     wrms, clds = error_signals(err_sk)
 
     # BFBsk
-    bfb_sk = np.array(
+    bfb_sk = np.asarray(
         [
             1.754,
             0.325,
@@ -748,7 +748,7 @@ def skin_blood_flow(
         ],
     )
     # SKIND
-    skin_dilat = np.array(
+    skin_dilat = np.asarray(
         [
             0.0692,
             0.0992,
@@ -770,7 +770,7 @@ def skin_blood_flow(
         ],
     )
     # SKINC
-    skin_stric = np.array(
+    skin_stric = np.asarray(
         [
             0.0213,
             0.0213,
@@ -802,7 +802,7 @@ def skin_blood_flow(
         sd_dilat = np.ones(Default.num_body_parts)
         sd_stric = np.ones(Default.num_body_parts)
     else:  # age >= 60
-        sd_dilat = np.array(
+        sd_dilat = np.asarray(
             [
                 0.91,
                 0.91,
@@ -1007,7 +1007,7 @@ def local_mbase(
     """
     mbase_all = basal_met(height, weight, age, sex, bmr_equation)
     # Distribution coefficient of basal metabolic rate
-    mbf_cr = np.array(
+    mbf_cr = np.asarray(
         [
             0.19551,
             0.00324,
@@ -1028,7 +1028,7 @@ def local_mbase(
             0.00250,
         ],
     )
-    mbf_ms = np.array(
+    mbf_ms = np.asarray(
         [
             0.00252,
             0.0,
@@ -1049,7 +1049,7 @@ def local_mbase(
             0.0,
         ],
     )
-    mbf_fat = np.array(
+    mbf_fat = np.asarray(
         [
             0.00127,
             0.0,
@@ -1070,7 +1070,7 @@ def local_mbase(
             0.0,
         ],
     )
-    mbf_sk = np.array(
+    mbf_sk = np.asarray(
         [
             0.00152,
             0.00033,
@@ -1126,7 +1126,7 @@ def local_q_work(bmr, par):
     q_work_all = (par - 1) * bmr
 
     # Distribution coefficient of thermogenesis by work
-    workf = np.array(
+    workf = np.asarray(
         [
             0,
             0,
@@ -1198,7 +1198,7 @@ def shivering(
     wrms, clds = error_signals(err_sk)
 
     # Distribution coefficient of thermogenesis by shivering
-    shivf = np.array(
+    shivf = np.asarray(
         [
             0.0339,
             0.0436,
@@ -1353,7 +1353,7 @@ def nonshivering(
     sig_nst = min(sig_nst, thres)
 
     # Distribution coefficient of thermogenesis by non-shivering
-    nstf = np.array(
+    nstf = np.asarray(
         [
             0.000,
             0.190,
@@ -1460,7 +1460,7 @@ def cr_ms_fat_blood_flow(
     """
     # Basal blood flow rate [L/h]
     # core, CBFB
-    bfb_core = np.array(
+    bfb_core = np.asarray(
         [
             35.251,
             15.240,
@@ -1482,7 +1482,7 @@ def cr_ms_fat_blood_flow(
         ],
     )
     # muscle, MSBFB
-    bfb_muscle = np.array(
+    bfb_muscle = np.asarray(
         [
             0.682,
             0.0,
@@ -1504,7 +1504,7 @@ def cr_ms_fat_blood_flow(
         ],
     )
     # fat, FTBFB
-    bfb_fat = np.array(
+    bfb_fat = np.asarray(
         [
             0.265,
             0.0,

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -100,10 +100,10 @@ def adaptive_ashrae(
         units=units,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    t_running_mean = np.array(t_running_mean)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    t_running_mean = np.asarray(t_running_mean)
+    v = np.asarray(v)
     standard = "ashrae"
 
     if units.upper() == Units.IP.value:

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -81,10 +81,10 @@ def adaptive_en(
     # Validate inputs using the ENInputs class
     ENInputs(tdb=tdb, tr=tr, t_running_mean=t_running_mean, v=v, units=units)
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    t_running_mean = np.array(t_running_mean)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    t_running_mean = np.asarray(t_running_mean)
+    v = np.asarray(v)
     standard = "iso"
 
     if units.upper() == Units.IP.value:

--- a/pythermalcomfort/models/ankle_draft.py
+++ b/pythermalcomfort/models/ankle_draft.py
@@ -101,13 +101,13 @@ def ankle_draft(
     )
 
     # Convert lists to numpy arrays
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    vr = np.array(vr)
-    rh = np.array(rh)
-    met = np.array(met)
-    clo = np.array(clo)
-    v_ankle = np.array(v_ankle)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    vr = np.asarray(vr)
+    rh = np.asarray(rh)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    v_ankle = np.asarray(v_ankle)
 
     if units.upper() == Units.IP.value:
         tdb, tr, vr, v_ankle = units_converter(tdb=tdb, tr=tr, vr=vr, vel=v_ankle)

--- a/pythermalcomfort/models/at.py
+++ b/pythermalcomfort/models/at.py
@@ -60,16 +60,16 @@ def at(
     ATInputs(tdb=tdb, rh=rh, v=v, q=q, round_output=round_output)
 
     # Convert lists to numpy arrays if necessary
-    tdb = np.array(tdb)
-    rh = np.array(rh)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
+    v = np.asarray(v)
 
     # Calculate vapor pressure
     p_vap = psy_ta_rh(tdb, rh).p_vap / 100
 
     # Calculate apparent temperature
     if q is not None:
-        q = np.array(q)
+        q = np.asarray(q)
         t_at = tdb + 0.348 * p_vap - 0.7 * v + 0.7 * q / (v + 10) - 4.25
     else:
         t_at = tdb + 0.33 * p_vap - 0.7 * v - 4.00

--- a/pythermalcomfort/models/clo_tout.py
+++ b/pythermalcomfort/models/clo_tout.py
@@ -67,7 +67,7 @@ def clo_tout(
     )
 
     # Convert tout to NumPy array for vectorized operations
-    tout = np.array(tout)
+    tout = np.asarray(tout)
 
     # Convert units if necessary
     if units.upper() == Units.IP.value:

--- a/pythermalcomfort/models/cooling_effect.py
+++ b/pythermalcomfort/models/cooling_effect.py
@@ -118,13 +118,13 @@ def cooling_effect(
         units=units,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    vr = np.array(vr)
-    rh = np.array(rh)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    vr = np.asarray(vr)
+    rh = np.asarray(rh)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
 
     if units.upper() == Units.IP.value:
         tdb, tr, vr = units_converter(tdb=tdb, tr=tr, v=vr)

--- a/pythermalcomfort/models/discomfort_index.py
+++ b/pythermalcomfort/models/discomfort_index.py
@@ -61,8 +61,8 @@ def discomfort_index(
         rh=rh,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     di = tdb - 0.55 * (1 - 0.01 * rh) * (tdb - 14.5)
 

--- a/pythermalcomfort/models/esi.py
+++ b/pythermalcomfort/models/esi.py
@@ -51,9 +51,9 @@ def esi(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
-    sol_radiation_global = np.array(sol_radiation_global)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
+    sol_radiation_global = np.asarray(sol_radiation_global)
 
     _esi = (
         0.63 * tdb

--- a/pythermalcomfort/models/heat_index_lu.py
+++ b/pythermalcomfort/models/heat_index_lu.py
@@ -48,8 +48,8 @@ def heat_index_lu(
         limit_inputs=False,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     hi = _lu_heat_index_vectorized(tdb + 273.15, rh / 100) - 273.15
 

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -49,8 +49,8 @@ def heat_index_rothfusz(
         limit_inputs=limit_inputs,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     hi = -8.784695 + 1.61139411 * tdb + 2.338549 * rh - 0.14611605 * tdb * rh
     hi += -1.2308094 * 10**-2 * tdb**2 - 1.6424828 * 10**-2 * rh**2

--- a/pythermalcomfort/models/humidex.py
+++ b/pythermalcomfort/models/humidex.py
@@ -66,8 +66,8 @@ def humidex(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     if np.any(rh > 100) or np.any(rh < 0):
         raise ValueError("Relative humidity must be between 0 and 100%")

--- a/pythermalcomfort/models/jos3.py
+++ b/pythermalcomfort/models/jos3.py
@@ -276,7 +276,7 @@ class JOS3:
         model.tdb = 28  # Air temperature [°C]
         model.tr = 30  # Mean radiant temperature [°C]
         model.rh = 40  # Relative humidity [%]
-        model.v = np.array(  # Air velocity [m/s]
+        model.v = np.asarray(  # Air velocity [m/s]
             [
                 0.2,  # head
                 0.4,  # neck
@@ -1182,10 +1182,10 @@ class JOS3:
         for key, value in merged_data.items():
             if isinstance(value, defaultdict):
                 merged_data[key] = JOS3BodyParts(
-                    **{k: np.array(v) for k, v in value.items()},
+                    **{k: np.asarray(v) for k, v in value.items()},
                 )
             else:
-                merged_data[key] = np.array(value)
+                merged_data[key] = np.asarray(value)
 
         return JOS3Output(**merged_data)
 

--- a/pythermalcomfort/models/net.py
+++ b/pythermalcomfort/models/net.py
@@ -67,9 +67,9 @@ def net(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
+    v = np.asarray(v)
 
     frac = 1.0 / (1.76 + 1.4 * v**0.75)
     et = 37 - (37 - tdb) / (0.68 - 0.0014 * rh + frac) - 0.29 * tdb * (1 - 0.01 * rh)

--- a/pythermalcomfort/models/pet_steady.py
+++ b/pythermalcomfort/models/pet_steady.py
@@ -479,7 +479,7 @@ def _pet_steady_vectorised(
         return round(optimize.fsolve(f, pet_guess)[0], 2)
 
     # initial guess
-    t_guess = np.array([36.7, 34, 0.5 * (tdb + tr)])
+    t_guess = np.asarray([36.7, 34, 0.5 * (tdb + tr)])
     # solve for Tc, Tsk, Tcl temperatures
     t_stable = optimize.fsolve(
         solve_pet,

--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -252,14 +252,14 @@ def phs(
 
     kwargs = {**default_kwargs, **kwargs}
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    rh = np.array(rh)
-    met = np.array(met) * met_to_w_m2
-    clo = np.array(clo)
-    wme = np.array(wme) * met_to_w_m2
-    posture = np.array(posture)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    rh = np.asarray(rh)
+    met = np.asarray(met) * met_to_w_m2
+    clo = np.asarray(clo)
+    wme = np.asarray(wme) * met_to_w_m2
+    posture = np.asarray(posture)
 
     i_mst = kwargs["i_mst"]
     a_p = kwargs["a_p"]

--- a/pythermalcomfort/models/pmv_athb.py
+++ b/pythermalcomfort/models/pmv_athb.py
@@ -86,12 +86,12 @@ def pmv_athb(
     # Validate inputs using the ATHBInputs class
     ATHBInputs(tdb=tdb, tr=tr, vr=vr, rh=rh, met=met, t_running_mean=t_running_mean)
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    vr = np.array(vr)
-    met = np.array(met)
-    rh = np.array(rh)
-    t_running_mean = np.array(t_running_mean)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    vr = np.asarray(vr)
+    met = np.asarray(met)
+    rh = np.asarray(rh)
+    t_running_mean = np.asarray(t_running_mean)
 
     met_adapted = met - (0.234 * t_running_mean) / 58.2
 

--- a/pythermalcomfort/models/pmv_e.py
+++ b/pythermalcomfort/models/pmv_e.py
@@ -118,7 +118,7 @@ def pmv_e(
     )
 
     default_kwargs = {"units": units, "limit_inputs": limit_inputs}
-    met = np.array(met)
+    met = np.asarray(met)
     _pmv = pmv_ppd_iso(
         tdb=tdb,
         tr=tr,

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -155,13 +155,13 @@ def pmv_ppd_ashrae(
         airspeed_control=airspeed_control,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    rh = np.array(rh)
-    vr = np.array(vr)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    rh = np.asarray(rh)
+    vr = np.asarray(vr)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
 
     if units.upper() == Units.IP.value:
         tdb, tr, vr = units_converter(tdb=tdb, tr=tr, v=vr)

--- a/pythermalcomfort/models/pmv_ppd_iso.py
+++ b/pythermalcomfort/models/pmv_ppd_iso.py
@@ -146,13 +146,13 @@ def pmv_ppd_iso(
         limit_inputs=limit_inputs,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    rh = np.array(rh)
-    vr = np.array(vr)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    rh = np.asarray(rh)
+    vr = np.asarray(vr)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
 
     if units.upper() == Units.IP.value:
         tdb, tr, vr = units_converter(tdb=tdb, tr=tr, v=vr)

--- a/pythermalcomfort/models/set_tmp.py
+++ b/pythermalcomfort/models/set_tmp.py
@@ -93,13 +93,13 @@ def set_tmp(
         print(result.set)  # [24.3, 24.3]
 
     """
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    rh = np.array(rh)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    rh = np.asarray(rh)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
 
     # Validate inputs using the SetTmpInputs class
     SETInputs(

--- a/pythermalcomfort/models/solar_gain.py
+++ b/pythermalcomfort/models/solar_gain.py
@@ -114,14 +114,14 @@ def solar_gain(
         floor_reflectance=floor_reflectance,
     )
 
-    sol_altitude = np.array(sol_altitude)
-    sharp = np.array(sharp)
-    sol_radiation_dir = np.array(sol_radiation_dir)
-    sol_transmittance = np.array(sol_transmittance)
-    f_svv = np.array(f_svv)
-    f_bes = np.array(f_bes)
-    asw = np.array(asw)
-    floor_reflectance = np.array(floor_reflectance)
+    sol_altitude = np.asarray(sol_altitude)
+    sharp = np.asarray(sharp)
+    sol_radiation_dir = np.asarray(sol_radiation_dir)
+    sol_transmittance = np.asarray(sol_transmittance)
+    f_svv = np.asarray(f_svv)
+    f_bes = np.asarray(f_bes)
+    asw = np.asarray(asw)
+    floor_reflectance = np.asarray(floor_reflectance)
 
     posture = posture.lower()
     if posture not in [

--- a/pythermalcomfort/models/thi.py
+++ b/pythermalcomfort/models/thi.py
@@ -39,8 +39,8 @@ def thi(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     _thi = 1.8 * tdb + 32 - 0.55 * (1 - 0.01 * rh) * (1.8 * tdb - 26)
 

--- a/pythermalcomfort/models/two_nodes_gagge.py
+++ b/pythermalcomfort/models/two_nodes_gagge.py
@@ -115,14 +115,14 @@ def two_nodes_gagge(
         w_max=w_max,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    rh = np.array(rh)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
-    position = np.array(position)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    rh = np.asarray(rh)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
+    position = np.asarray(position)
 
     vapor_pressure = rh * p_sat_torr(tdb) / 100
 

--- a/pythermalcomfort/models/two_nodes_gagge_ji.py
+++ b/pythermalcomfort/models/two_nodes_gagge_ji.py
@@ -117,15 +117,15 @@ def two_nodes_gagge_ji(
         error_msg = f"Unexpected keyword arguments: {list(kwargs.keys())}"
         raise TypeError(error_msg)
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    met = np.array(met)
-    clo = np.array(clo)
-    vapor_pressure = np.array(vapor_pressure)
-    wme = np.array(wme)
-    body_surface_area = np.array(body_surface_area)
-    p_atm = np.array(p_atm)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    vapor_pressure = np.asarray(vapor_pressure)
+    wme = np.asarray(wme)
+    body_surface_area = np.asarray(body_surface_area)
+    p_atm = np.asarray(p_atm)
 
     # Validate inputs
     GaggeTwoNodesJiInputs(
@@ -450,4 +450,4 @@ def _two_nodes_ji_optimized(
         skin_temp_hist.append(t_skin)
         core_temp_hist.append(t_core)
 
-    return {"t_core": np.array(core_temp_hist), "t_skin": np.array(skin_temp_hist)}
+    return {"t_core": np.asarray(core_temp_hist), "t_skin": np.asarray(skin_temp_hist)}

--- a/pythermalcomfort/models/two_nodes_gagge_sleep.py
+++ b/pythermalcomfort/models/two_nodes_gagge_sleep.py
@@ -182,7 +182,7 @@ def two_nodes_gagge_sleep(
         for key in results[0]:
             vals = [d[key] for d in results]
             # only wrap in an array if there’s more than one element
-            output[key] = np.array(vals) if len(vals) > 1 else vals[0]
+            output[key] = np.asarray(vals) if len(vals) > 1 else vals[0]
 
     return GaggeTwoNodesSleep(**output)
 

--- a/pythermalcomfort/models/use_fans_heatwaves.py
+++ b/pythermalcomfort/models/use_fans_heatwaves.py
@@ -111,13 +111,13 @@ def use_fans_heatwaves(
         limit_inputs=limit_inputs,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    rh = np.array(rh)
-    met = np.array(met)
-    clo = np.array(clo)
-    wme = np.array(wme)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    rh = np.asarray(rh)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    wme = np.asarray(wme)
 
     output = two_nodes_gagge(
         tdb,

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -82,10 +82,10 @@ def utci(
         limit_inputs=limit_inputs,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    v = np.array(v)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    v = np.asarray(v)
+    rh = np.asarray(rh)
 
     if units.upper() == Units.IP.value:
         tdb, tr, v = units_converter(tdb=tdb, tr=tr, v=v)

--- a/pythermalcomfort/models/vertical_tmp_grad_ppd.py
+++ b/pythermalcomfort/models/vertical_tmp_grad_ppd.py
@@ -96,12 +96,12 @@ def vertical_tmp_grad_ppd(
         vertical_tmp_grad=vertical_tmp_grad,
     )
 
-    tdb = np.array(tdb)
-    tr = np.array(tr)
-    vr = np.array(vr)
-    met = np.array(met)
-    clo = np.array(clo)
-    vertical_tmp_grad = np.array(vertical_tmp_grad)
+    tdb = np.asarray(tdb)
+    tr = np.asarray(tr)
+    vr = np.asarray(vr)
+    met = np.asarray(met)
+    clo = np.asarray(clo)
+    vertical_tmp_grad = np.asarray(vertical_tmp_grad)
 
     (
         tdb_valid,

--- a/pythermalcomfort/models/wbgt.py
+++ b/pythermalcomfort/models/wbgt.py
@@ -77,9 +77,9 @@ def wbgt(
         round_output=round_output,
     )
 
-    twb = np.array(twb)
-    tg = np.array(tg)
-    tdb = np.array(tdb) if tdb is not None else None
+    twb = np.asarray(twb)
+    tg = np.asarray(tg)
+    tdb = np.asarray(tdb) if tdb is not None else None
 
     if with_solar_load and tdb is None:
         raise ValueError("Please enter the dry bulb air temperature")

--- a/pythermalcomfort/models/wci.py
+++ b/pythermalcomfort/models/wci.py
@@ -62,8 +62,8 @@ def wci(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    v = np.asarray(v)
 
     _wci = (10.45 + 10 * v**0.5 - v) * (33 - tdb)
 

--- a/pythermalcomfort/models/wind_chill_temperature.py
+++ b/pythermalcomfort/models/wind_chill_temperature.py
@@ -54,8 +54,8 @@ def wind_chill_temperature(
         round_output=round_output,
     )
 
-    tdb = np.array(tdb)
-    v = np.array(v)
+    tdb = np.asarray(tdb)
+    v = np.asarray(v)
 
     _wct = 13.12 + 0.6215 * tdb - 11.37 * v**0.16 + 0.3965 * tdb * v**0.16
 

--- a/pythermalcomfort/models/work_capacity_dunne.py
+++ b/pythermalcomfort/models/work_capacity_dunne.py
@@ -50,7 +50,7 @@ def work_capacity_dunne(
 
     # convert str to enum
     work_intensity = WorkIntensity(work_intensity.lower())
-    wbgt = np.array(wbgt)
+    wbgt = np.asarray(wbgt)
 
     capacity = np.clip((100 - (25 * (np.maximum(0, wbgt - 25)) ** (2 / 3))), 0, 100)
 

--- a/pythermalcomfort/models/work_capacity_hothaps.py
+++ b/pythermalcomfort/models/work_capacity_hothaps.py
@@ -69,7 +69,7 @@ def work_capacity_hothaps(
 
     # convert str to enum
     work_intensity = WorkIntensity(work_intensity.lower())
-    wbgt = np.array(wbgt)
+    wbgt = np.asarray(wbgt)
 
     params = {
         WorkIntensity.HEAVY: {"divisor": 30.94, "exponent": 16.64},

--- a/pythermalcomfort/models/work_capacity_iso.py
+++ b/pythermalcomfort/models/work_capacity_iso.py
@@ -46,8 +46,8 @@ def work_capacity_iso(
     # Validate inputs
     WorkCapacityStandardsInputs(wbgt=wbgt, met=met)
 
-    wbgt = np.array(wbgt)
-    met = np.array(met)
+    wbgt = np.asarray(wbgt)
+    met = np.asarray(met)
 
     met_rest = 117  # assumed resting metabolic rate
 

--- a/pythermalcomfort/models/work_capacity_niosh.py
+++ b/pythermalcomfort/models/work_capacity_niosh.py
@@ -46,8 +46,8 @@ def work_capacity_niosh(
     # Validate inputs
     WorkCapacityStandardsInputs(wbgt=wbgt, met=met)
 
-    wbgt = np.array(wbgt)
-    met = np.array(met)
+    wbgt = np.asarray(wbgt)
+    met = np.asarray(met)
 
     met_rest = 117  # assumed resting metabolic rate
 

--- a/pythermalcomfort/shared_functions.py
+++ b/pythermalcomfort/shared_functions.py
@@ -23,6 +23,6 @@ def mapping(value, map_dictionary, right=True):
     Stress category for each input temperature.
 
     """
-    bins = np.array(list(map_dictionary.keys()))
-    words = np.append(np.array(list(map_dictionary.values())), "unknown")
+    bins = np.asarray(list(map_dictionary.keys()))
+    words = np.append(np.asarray(list(map_dictionary.values())), "unknown")
     return words[np.digitize(value, bins, right=right)]

--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -149,7 +149,7 @@ def antoine(tdb: float | np.ndarray) -> np.ndarray:
         Saturated vapor pressure [kPa].
 
     """
-    tdb = np.array(tdb)
+    tdb = np.asarray(tdb)
     return math.e ** (16.6536 - 4030.183 / (tdb + 235))
 
 
@@ -189,8 +189,8 @@ def psy_ta_rh(
         enthalpy_air [J/kg dry air]
 
     """
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     p_saturation = p_sat(tdb)
     p_vap = rh / 100 * p_saturation
@@ -258,8 +258,8 @@ def dew_point_tmp(
         dew point temperature, [°C]
 
     """
-    tdb = np.array(tdb)
-    rh = np.array(rh)
+    tdb = np.asarray(tdb)
+    rh = np.asarray(rh)
 
     c = 257.14
     b = 18.678
@@ -312,10 +312,10 @@ def mean_radiant_tmp(
     """
     standard = standard.lower()
 
-    tdb = np.array(tdb)
-    tg = np.array(tg)
-    v = np.array(v)
-    d = np.array(d)
+    tdb = np.asarray(tdb)
+    tg = np.asarray(tg)
+    v = np.asarray(v)
+    d = np.asarray(d)
 
     if standard == "mixed convection":
         mu = 0.0000181  # Pa s
@@ -629,8 +629,8 @@ def v_relative(v: float | list[float], met: float | list[float]) -> np.ndarray:
         relative air speed, [m/s]
 
     """
-    v = np.array(v)
-    met = np.array(met)
+    v = np.asarray(v)
+    met = np.asarray(met)
     return np.where(met > 1, np.around(v + 0.3 * (met - 1), 3), v)
 
 
@@ -666,8 +666,8 @@ def clo_dynamic_ashrae(
         dynamic clothing insulation (I :sub:`cl,r`), [clo]
 
     """
-    clo = np.array(clo)
-    met = np.array(met)
+    clo = np.asarray(clo)
+    met = np.asarray(met)
 
     model = model.lower()
     if model not in [Models.ashrae_55_2023.value]:
@@ -717,10 +717,10 @@ def clo_dynamic_iso(
         invalid_model_msg = f"PMV calculations can only be performed in compliance with ISO {Models.iso_9920_2007.value}"
         raise ValueError(invalid_model_msg)
 
-    clo = np.array(clo)
-    met = np.array(met)
-    i_a = np.array(i_a)
-    v = np.array(v)
+    clo = np.asarray(clo)
+    met = np.asarray(met)
+    i_a = np.asarray(i_a)
+    v = np.asarray(v)
 
     f_cl = clo_area_factor(i_cl=clo)
     i_t = clo + i_a / f_cl
@@ -884,7 +884,7 @@ def clo_intrinsic_insulation_ensemble(
         intrinsic insulation of the clothing ensemble, [clo]
 
     """
-    clo_garments = np.array(clo_garments)
+    clo_garments = np.asarray(clo_garments)
     return np.sum(clo_garments) * 0.835 + 0.161
 
 
@@ -907,7 +907,7 @@ def clo_area_factor(i_cl: float | list[float]) -> float | list[float]:
         area factor of the clothing ensemble, [m2]
 
     """
-    i_cl = np.array(i_cl)
+    i_cl = np.asarray(i_cl)
     return 1 + 0.28 * i_cl
 
 
@@ -942,9 +942,9 @@ def clo_insulation_air_layer(
         boundary air layer insulation, [clo]
 
     """
-    vr = np.array(vr)
-    v_walk = np.array(v_walk)
-    i_a_static = np.array(i_a_static)
+    vr = np.asarray(vr)
+    v_walk = np.asarray(v_walk)
+    i_a_static = np.asarray(i_a_static)
 
     return (
         np.exp(
@@ -1001,11 +1001,11 @@ def clo_total_insulation(
         total insulation of the clothing ensemble, [clo]
 
     """
-    i_t = np.array(i_t)
-    vr = np.array(vr)
-    v_walk = np.array(v_walk)
-    i_a_static = np.array(i_a_static)
-    i_cl = np.array(i_cl)
+    i_t = np.asarray(i_t)
+    vr = np.asarray(vr)
+    v_walk = np.asarray(v_walk)
+    i_a_static = np.asarray(i_a_static)
+    i_cl = np.asarray(i_cl)
 
     def normal_clothing(_vr, _vw, _i_t) -> float:
         return _i_t * _correction_normal_clothing(_vw=_vw, _vr=_vr)
@@ -1058,9 +1058,9 @@ def clo_correction_factor_environment(
         (`I`:sub:`cl,r` / (`I`:sub:`cl`))
 
     """
-    vr = np.array(vr)
-    v_walk = np.array(v_walk)
-    i_cl = np.array(i_cl)
+    vr = np.asarray(vr)
+    v_walk = np.asarray(v_walk)
+    i_cl = np.asarray(i_cl)
 
     def correction_low_clothing(_vr, _vw, _i_cl) -> float:
         return (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def is_equal(a, b, tolerance=1e-6) -> bool:
     """Compare two values for equality with a specified tolerance."""
     if isinstance(a, np.ndarray):
         if not isinstance(b, np.ndarray):
-            b = np.array(b, dtype=a.dtype)
+            b = np.asarray(b, dtype=a.dtype)
         if a.dtype.kind in "UOS":  # U = unicode, O = objects, S = string
             return np.array_equal(a, b)
         b = np.where(b is None, np.nan, b)  # Replace None with np.nan

--- a/tests/test_jos3.py
+++ b/tests/test_jos3.py
@@ -632,7 +632,7 @@ def test_vessel_blood_flow() -> None:
 def test_conv_coef() -> None:
     """Test the conv_coef function for calculating convective coefficients based on posture."""
     # Test case 1: Default values
-    hc_expected = np.array(
+    hc_expected = np.asarray(
         [
             4.48,
             4.48,
@@ -659,7 +659,7 @@ def test_conv_coef() -> None:
     )
 
     # Test case 2: Sitting posture
-    hc_expected = np.array(
+    hc_expected = np.asarray(
         [
             4.75,
             4.75,
@@ -692,7 +692,7 @@ def test_conv_coef() -> None:
     # Test case 4: Lying posture with different tdb and t_skin values
     tdb = np.full(17, 28.8)
     t_skin = np.full(17, 34.0)
-    hc_expected = np.array(
+    hc_expected = np.asarray(
         [
             1.105,
             1.105,
@@ -714,7 +714,7 @@ def test_conv_coef() -> None:
         ],
     ) * (
         abs(tdb - t_skin)
-        ** np.array(
+        ** np.asarray(
             [
                 0.345,
                 0.345,
@@ -743,7 +743,7 @@ def test_conv_coef() -> None:
 
     # Test case 5: Forced convection (v > 0.2)
     v = np.full(17, 0.3)
-    hc_expected = np.array(
+    hc_expected = np.asarray(
         [
             15.0,
             15.0,
@@ -765,7 +765,7 @@ def test_conv_coef() -> None:
         ],
     ) * (
         v
-        ** np.array(
+        ** np.asarray(
             [
                 0.62,
                 0.62,
@@ -797,7 +797,7 @@ def test_rad_coef() -> None:
     """Test the rad_coef function for calculating radiative coefficients based on posture."""
     # Test with valid postures
     valid_postures = {
-        "standing": np.array(
+        "standing": np.asarray(
             [
                 4.89,
                 4.89,
@@ -818,7 +818,7 @@ def test_rad_coef() -> None:
                 6.14,
             ],
         ),
-        "sitting": np.array(
+        "sitting": np.asarray(
             [
                 4.96,
                 4.96,
@@ -839,7 +839,7 @@ def test_rad_coef() -> None:
                 6.36,
             ],
         ),
-        "lying": np.array(
+        "lying": np.asarray(
             [
                 5.475,
                 5.475,
@@ -860,7 +860,7 @@ def test_rad_coef() -> None:
                 6.085,
             ],
         ),
-        "sedentary": np.array(
+        "sedentary": np.asarray(
             [
                 4.96,
                 4.96,
@@ -881,7 +881,7 @@ def test_rad_coef() -> None:
                 6.36,
             ],
         ),
-        "supine": np.array(
+        "supine": np.asarray(
             [
                 5.475,
                 5.475,
@@ -968,19 +968,19 @@ def test_operative_temp() -> None:
     )  # Since tdb and tr are the same, to should also be the same
 
     # Test with array inputs
-    tdb = np.array([20.0, 22.0, 24.0])
-    tr = np.array([25.0, 27.0, 29.0])
-    hc = np.array([0.5, 0.6, 0.7])
-    hr = np.array([0.5, 0.4, 0.3])
+    tdb = np.asarray([20.0, 22.0, 24.0])
+    tr = np.asarray([25.0, 27.0, 29.0])
+    hc = np.asarray([0.5, 0.6, 0.7])
+    hr = np.asarray([0.5, 0.4, 0.3])
     to = operative_temp(tdb, tr, hc, hr)
     expected_to = (hc * tdb + hr * tr) / (hc + hr)
     assert np.allclose(to, expected_to)
 
     # Test with mixed scalar and array inputs
     tdb = 20.0
-    tr = np.array([25.0, 27.0, 29.0])
+    tr = np.asarray([25.0, 27.0, 29.0])
     hc = 0.5
-    hr = np.array([0.5, 0.4, 0.3])
+    hr = np.asarray([0.5, 0.4, 0.3])
     to = operative_temp(tdb, tr, hc, hr)
     expected_to = (hc * tdb + hr * tr) / (hc + hr)
     assert np.allclose(to, expected_to)
@@ -1004,8 +1004,8 @@ def test_clo_area_factor() -> None:
     assert clo_area_factor(clo) == pytest.approx(expected_result, rel=1e-3)
 
     # Test with array values
-    clo = np.array([0.4, 0.6, 0.2])
-    expected_result = np.array([1.08, 1.11, 1.04])
+    clo = np.asarray([0.4, 0.6, 0.2])
+    expected_result = np.asarray([1.08, 1.11, 1.04])
     np.testing.assert_allclose(clo_area_factor(clo), expected_result, rtol=1e-3)
 
 
@@ -1017,10 +1017,10 @@ def test_dry_r() -> None:
     assert dry_r(hc, hr, clo) == pytest.approx(expected_result, rel=1e-3)
 
     # Test with array values
-    hc = np.array([3, 3])
-    hr = np.array([5, 5])
-    clo = np.array([0.5, 0.5])
-    expected_result = np.array([0.191, 0.191])
+    hc = np.asarray([3, 3])
+    hr = np.asarray([5, 5])
+    clo = np.asarray([0.5, 0.5])
+    expected_result = np.asarray([0.191, 0.191])
     assert dry_r(hc, hr, clo) == pytest.approx(expected_result, rel=1e-3)
 
     # Test with zero values
@@ -1045,11 +1045,11 @@ def test_wet_r() -> None:
     assert wet_r(hc, clo, i_clo, lewis_rate) == pytest.approx(expected_result, rel=1e-3)
 
     # Test with array values
-    hc = np.array([10.0, 10.0])
-    clo = np.array([0.5, 0.5])
-    i_clo = np.array([0.45, 0.45])
+    hc = np.asarray([10.0, 10.0])
+    clo = np.asarray([0.5, 0.5])
+    i_clo = np.asarray([0.45, 0.45])
     lewis_rate = 16.5
-    expected_result = np.array(
+    expected_result = np.asarray(
         [0.01594, 0.01594],
     )  # Replace with actual expected result based on your function's logic
     np.testing.assert_allclose(
@@ -1087,7 +1087,7 @@ def test_error_signals() -> None:
     assert clds > 0
 
     # Test with array
-    err_sk = np.array(
+    err_sk = np.asarray(
         [-2, 2, -3, 3, -1, 1, 0, -0.5, 0.5, -2, 2, -1, 1, -0.5, 0.5, -1, 1],
     )
     wrms, clds = error_signals(err_sk)
@@ -1095,7 +1095,7 @@ def test_error_signals() -> None:
     assert clds > 0
 
     # Test with wrong length array
-    err_sk = np.array([-2, 2, -3])
+    err_sk = np.asarray([-2, 2, -3])
     with pytest.raises(ValueError):
         error_signals(err_sk)
 
@@ -1103,8 +1103,8 @@ def test_error_signals() -> None:
 def test_evaporation() -> None:
     """Test the evaporation function for calculating evaporation rate."""
     # Test with basic parameters
-    err_cr = np.array([0.5])
-    err_sk = np.array(
+    err_cr = np.asarray([0.5])
+    err_sk = np.asarray(
         [
             0.2,
             0.3,
@@ -1125,10 +1125,10 @@ def test_evaporation() -> None:
             1.8,
         ],
     )
-    t_skin = np.array([34.0] * 17)
-    tdb = np.array([25.0] * 17)
-    rh = np.array([50.0] * 17)
-    ret = np.array([0.01] * 17)
+    t_skin = np.asarray([34.0] * 17)
+    tdb = np.asarray([25.0] * 17)
+    rh = np.asarray([50.0] * 17)
+    ret = np.asarray([0.01] * 17)
 
     wet, e_sk, e_max, e_sweat = evaporation(
         err_cr,
@@ -1151,12 +1151,12 @@ def test_evaporation() -> None:
     assert np.all(wet <= 1)
 
     # Test age effects
-    err_cr = np.array([0.5])
-    err_sk = np.array([0.2] * 17)
-    t_skin = np.array([34.0] * 17)
-    tdb = np.array([25.0] * 17)
-    rh = np.array([50.0] * 17)
-    ret = np.array([0.01] * 17)
+    err_cr = np.asarray([0.5])
+    err_sk = np.asarray([0.2] * 17)
+    t_skin = np.asarray([34.0] * 17)
+    tdb = np.asarray([25.0] * 17)
+    rh = np.asarray([50.0] * 17)
+    ret = np.asarray([0.01] * 17)
 
     wet_young, e_sk_young, e_max_young, e_sweat_young = evaporation(
         err_cr,
@@ -1186,12 +1186,12 @@ def test_evaporation() -> None:
     assert np.all(e_sweat_old <= e_sweat_young)
 
     # Test with valid BSA equations
-    err_cr = np.array([0.5])
-    err_sk = np.array([0.2] * 17)
-    t_skin = np.array([34.0] * 17)
-    tdb = np.array([25.0] * 17)
-    rh = np.array([50.0] * 17)
-    ret = np.array([0.01] * 17)
+    err_cr = np.asarray([0.5])
+    err_sk = np.asarray([0.2] * 17)
+    t_skin = np.asarray([34.0] * 17)
+    tdb = np.asarray([25.0] * 17)
+    rh = np.asarray([50.0] * 17)
+    ret = np.asarray([0.01] * 17)
 
     valid_bsa_equations_list = ["dubois", "takahira", "fujimoto", "kurazumi"]
     for bsa_equation in valid_bsa_equations_list:
@@ -1230,9 +1230,9 @@ def test_evaporation() -> None:
         )
 
     # Test to ensure no errors occur when e_max is zero
-    t_skin = np.array([34.0] * 17)
-    tdb = np.array([34.0] * 17)
-    rh = np.array([100] * 17)
+    t_skin = np.asarray([34.0] * 17)
+    tdb = np.asarray([34.0] * 17)
+    rh = np.asarray([100] * 17)
 
     # Call the evaporation function
     wet, e_sk, e_max, e_sweat = evaporation(
@@ -1262,8 +1262,8 @@ def test_evaporation() -> None:
 def test_skin_blood_flow() -> None:
     """Test the skin_blood_flow function for calculating blood flow in the skin."""
     # Test with basic values
-    err_cr = np.array([0.5])
-    err_sk = np.array(
+    err_cr = np.asarray([0.5])
+    err_sk = np.asarray(
         [
             0.2,
             0.3,
@@ -1299,8 +1299,8 @@ def test_skin_blood_flow() -> None:
     assert np.all(bf_skin >= 0)
 
     # Test age effect
-    err_cr = np.array([0.5])
-    err_sk = np.array([0.2] * 17)
+    err_cr = np.asarray([0.5])
+    err_sk = np.asarray([0.2] * 17)
 
     bf_skin_young = skin_blood_flow(
         err_cr,
@@ -1326,8 +1326,8 @@ def test_skin_blood_flow() -> None:
     # Test valid BSA equation
     valid_bsa_equations_list = ["dubois", "takahira", "fujimoto", "kurazumi"]
     for bsa_equation in valid_bsa_equations_list:
-        err_cr = np.array([0.5])
-        err_sk = np.array([0.2] * 17)
+        err_cr = np.asarray([0.5])
+        err_sk = np.asarray([0.2] * 17)
 
         bf_skin: np.ndarray = skin_blood_flow(
             err_cr,
@@ -1359,8 +1359,8 @@ def test_skin_blood_flow() -> None:
 def test_ava_blood_flow() -> None:
     """Test the ava_blood_flow function for calculating blood flow in arteriovenous anastomoses (AVA)."""
     # Test with basic parameters
-    err_cr = np.array([0.5, 0.6, 0.7, 0.8, 0.9])
-    err_sk = np.array(
+    err_cr = np.asarray([0.5, 0.6, 0.7, 0.8, 0.9])
+    err_sk = np.asarray(
         [
             0.2,
             0.3,
@@ -1398,8 +1398,8 @@ def test_ava_blood_flow() -> None:
     assert bf_ava_foot >= 0
 
     # Test age effect
-    err_cr = np.array([0.5, 0.6, 0.7, 0.8, 0.9])
-    err_sk = np.array([0.2] * 17)
+    err_cr = np.asarray([0.5, 0.6, 0.7, 0.8, 0.9])
+    err_sk = np.asarray([0.2] * 17)
 
     bf_ava_hand_young, bf_ava_foot_young = ava_blood_flow(
         err_cr,
@@ -1424,8 +1424,8 @@ def test_ava_blood_flow() -> None:
     assert bf_ava_foot_old <= bf_ava_foot_young
 
     # Test with input length mismatch
-    err_cr = np.array([0.5, 0.6, 0.7])
-    err_sk = np.array([0.2, 0.3])
+    err_cr = np.asarray([0.5, 0.6, 0.7])
+    err_sk = np.asarray([0.2, 0.3])
     with pytest.raises(TypeError):
         ava_blood_flow(
             err_cr,
@@ -1438,8 +1438,8 @@ def test_ava_blood_flow() -> None:
         )
 
     # Test with zero signal
-    err_cr = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
-    err_sk = np.array([0.0] * 17)
+    err_cr = np.asarray([0.0, 0.0, 0.0, 0.0, 0.0])
+    err_sk = np.asarray([0.0] * 17)
     bf_ava_hand, bf_ava_foot = ava_blood_flow(
         err_cr,
         err_sk,
@@ -1739,10 +1739,10 @@ def test_cold_acclimation_non_shivering() -> None:
 def test_sum_bf() -> None:
     """Test the sum_bf function for calculating body fat."""
     # Test to check output type
-    bf_core = np.array([1, 2, 3, 4])
-    bf_muscle = np.array([1, 2, 3, 4])
-    bf_fat = np.array([1, 2, 3, 4])
-    bf_skin = np.array([1, 2, 3, 4])
+    bf_core = np.asarray([1, 2, 3, 4])
+    bf_muscle = np.asarray([1, 2, 3, 4])
+    bf_fat = np.asarray([1, 2, 3, 4])
+    bf_skin = np.asarray([1, 2, 3, 4])
     bf_ava_hand = 1.0
     bf_ava_foot = 1.0
 
@@ -1750,10 +1750,10 @@ def test_sum_bf() -> None:
     assert isinstance(co, float)
 
     # Test with custom values 1
-    bf_core = np.array([1, 2, 3, 4])
-    bf_muscle = np.array([1, 2, 3, 4])
-    bf_fat = np.array([1, 2, 3, 4])
-    bf_skin = np.array([1, 2, 3, 4])
+    bf_core = np.asarray([1, 2, 3, 4])
+    bf_muscle = np.asarray([1, 2, 3, 4])
+    bf_fat = np.asarray([1, 2, 3, 4])
+    bf_skin = np.asarray([1, 2, 3, 4])
     bf_ava_hand = 1.0
     bf_ava_foot = 1.0
 
@@ -1769,10 +1769,10 @@ def test_sum_bf() -> None:
     assert co == expected_co
 
     # Test with custom values 2
-    bf_core = np.array([1, 2, 3, 4])
-    bf_muscle = np.array([1, 2, 3, 4])
-    bf_fat = np.array([1, 2, 3, 4])
-    bf_skin = np.array([1, 2, 3, 4])
+    bf_core = np.asarray([1, 2, 3, 4])
+    bf_muscle = np.asarray([1, 2, 3, 4])
+    bf_fat = np.asarray([1, 2, 3, 4])
+    bf_skin = np.asarray([1, 2, 3, 4])
     bf_ava_hand = 1.0
     bf_ava_foot = 1.0
 

--- a/tests/test_pmv_ppd_ashrae.py
+++ b/tests/test_pmv_ppd_ashrae.py
@@ -86,7 +86,7 @@ class TestPmvPpd:
                 [0.5, 0.5, 0.5, 0.5, 2.1, 1.9],
                 model=Models.ashrae_55_2023.value,
             ).pmv,
-            np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]),
+            np.asarray([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]),
         )
 
         np.testing.assert_equal(

--- a/tests/test_pmv_ppd_iso.py
+++ b/tests/test_pmv_ppd_iso.py
@@ -104,7 +104,7 @@ class TestPmvPpd:
                 [0.5, 0.5, 0.5, 0.5, 2.1, 0.1],
                 model=Models.iso_7730_2005.value,
             ).pmv,
-            np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]),
+            np.asarray([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]),
         )
 
         # check results with limit_inputs disabled

--- a/tests/test_scale_wind_speed_log.py
+++ b/tests/test_scale_wind_speed_log.py
@@ -47,8 +47,8 @@ def test_scale_winds_speed_scalar() -> None:
 
 def test_scale_winds_speed_array() -> None:
     """Test scaling wind speed for array inputs."""
-    v10 = np.array([3.0, 5.0])
-    z2 = np.array([1.5, 2.5])
+    v10 = np.asarray([3.0, 5.0])
+    z2 = np.asarray([1.5, 2.5])
     expected = v10 * np.log((z2 - 0.0) / 0.01) / np.log((10.0 - 0.0) / 0.01)
     result = scale_wind_speed_log(v10, z2, round_output=False)
     assert np.allclose(result.v_z2, expected, rtol=1e-5)
@@ -59,7 +59,7 @@ def test_scale_wind_speed_broadcasting() -> None:
     v10 = [3.0, 5.0]
     z2 = [1.5, 2.5]
     z0 = [0.01, 0.1]
-    expected = np.array(
+    expected = np.asarray(
         [
             3.0 * np.log((1.5 - 0.0) / 0.01) / np.log((10.0 - 0.0) / 0.01),
             5.0 * np.log((2.5 - 0.0) / 0.1) / np.log((10.0 - 0.0) / 0.1),

--- a/tests/test_solar_gain.py
+++ b/tests/test_solar_gain.py
@@ -34,6 +34,6 @@ def test_solar_gain_array() -> None:
             asw=0.7,
             posture="sitting",
         ).erf,
-        np.array([46.4, 52.8]),
+        np.asarray([46.4, 52.8]),
         atol=0.1,
     )

--- a/tests/test_two_nodes_gagge_sleep.py
+++ b/tests/test_two_nodes_gagge_sleep.py
@@ -11,16 +11,16 @@ def test_two_nodes_gagge_sleep_single_input() -> None:
 
     # expected outputs
     expected = {
-        "set": np.array([24.28]),
-        "t_core": np.array([37.03]),
-        "t_skin": np.array([33.67]),
-        "wet": np.array([0.27]),
-        "t_sens": np.array([1.12]),
-        "disc": np.array([1.47]),
-        "e_skin": np.array([28.75]),
-        "met_shivering": np.array([0.0]),
-        "alfa": np.array([0.13]),
-        "skin_blood_flow": np.array([7.11]),
+        "set": np.asarray([24.28]),
+        "t_core": np.asarray([37.03]),
+        "t_skin": np.asarray([33.67]),
+        "wet": np.asarray([0.27]),
+        "t_sens": np.asarray([1.12]),
+        "disc": np.asarray([1.47]),
+        "e_skin": np.asarray([28.75]),
+        "met_shivering": np.asarray([0.0]),
+        "alfa": np.asarray([0.13]),
+        "skin_blood_flow": np.asarray([7.11]),
     }
 
     # compare each field with a reasonable tolerance

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -31,7 +31,7 @@ def test_intrinsic_insulation_ensemble() -> None:
 def test_clo_area_factor() -> None:
     """Test the clothing area factor function."""
     assert clo_area_factor(1) == 1.28
-    assert np.allclose(clo_area_factor(i_cl=[1, 2]), np.array([1.28, 1.56]))
+    assert np.allclose(clo_area_factor(i_cl=[1, 2]), np.asarray([1.28, 1.56]))
 
 
 def test_clo_air_layer_insulation() -> None:
@@ -293,9 +293,9 @@ def test_clo_dynamic_ashrae() -> None:
     assert clo_dynamic_ashrae(clo=1, met=1) == 1
     assert clo_dynamic_ashrae(clo=1, met=0.5) == 1
     assert clo_dynamic_ashrae(clo=2, met=0.5) == 2
-    assert np.allclose(clo_dynamic_ashrae(1.0, 1.0), np.array(1))
-    assert np.allclose(clo_dynamic_ashrae(1.0, 1.2), np.array(1))
-    assert np.allclose(clo_dynamic_ashrae(1.0, 2.0), np.array(0.8))
+    assert np.allclose(clo_dynamic_ashrae(1.0, 1.0), np.asarray(1))
+    assert np.allclose(clo_dynamic_ashrae(1.0, 1.2), np.asarray(1))
+    assert np.allclose(clo_dynamic_ashrae(1.0, 2.0), np.asarray(0.8))
 
     # Test invalid standard input
     with pytest.raises(ValueError):
@@ -350,9 +350,9 @@ def test_v_relative() -> None:
     assert np.allclose(v_relative(v, met), expected_result)
 
     # Test case when met is greater than 1
-    v = np.array([1.0, 2.0, 3.0])
+    v = np.asarray([1.0, 2.0, 3.0])
     met = 2.0
-    expected_result = np.array([1.3, 2.3, 3.3])
+    expected_result = np.asarray([1.3, 2.3, 3.3])
     assert np.allclose(v_relative(v, met), expected_result, atol=1e-6)
 
     # Test case with negative values for v
@@ -371,7 +371,7 @@ def test_validate_type() -> None:
     validate_type(1, "int_value", allowed)
     validate_type(3.1415, "float_value", allowed)
     validate_type([1, 2, 3], "list_value", allowed)
-    validate_type(np.array([1, 2, 3]), "array_value", allowed)
+    validate_type(np.asarray([1, 2, 3]), "array_value", allowed)
 
     # np scalars should be converted to native types via .item()
     validate_type(np.float32(40.0), "np_float32", allowed)
@@ -379,11 +379,11 @@ def test_validate_type() -> None:
     validate_type(np.int64(200), "np_int64", allowed)
 
     # np array of floats and ints should be allowed
-    arr_numeric = np.array([np.float32(1.0), np.int32(2), 3, 3.52])
+    arr_numeric = np.asarray([np.float32(1.0), np.int32(2), 3, 3.52])
     validate_type(arr_numeric, "arr_numeric", allowed)
 
     # empty NumPy array should also pass
-    validate_type(np.array([]), "empty_array", allowed)
+    validate_type(np.asarray([]), "empty_array", allowed)
 
     # empty list should pass
     validate_type([], "empty_list", allowed)

--- a/tests/test_wind_chill_temperature.py
+++ b/tests/test_wind_chill_temperature.py
@@ -33,7 +33,7 @@ class TestWct:
         """Test that the function handles empty lists for tdb and v inputs."""
         # Test with empty lists
         assert np.allclose(
-            wind_chill_temperature(tdb=[], v=[]).wct, np.array([]), equal_nan=True
+            wind_chill_temperature(tdb=[], v=[]).wct, np.asarray([]), equal_nan=True
         )
 
     # Calculate WCT correctly for lists of temperature and wind speed values

--- a/tests/test_work_capacity_dunne.py
+++ b/tests/test_work_capacity_dunne.py
@@ -17,7 +17,7 @@ def test_heavy_array_and_clipping() -> None:
     wbgt = [20, 25, 28, 30, 35]
     wc = work_capacity_dunne(wbgt, "heavy")
     expected_base = np.clip(
-        100 - 25 * np.maximum(0, np.array(wbgt) - 25) ** (2 / 3),
+        100 - 25 * np.maximum(0, np.asarray(wbgt) - 25) ** (2 / 3),
         0,
         100,
     )

--- a/tests/test_work_capacity_iso.py
+++ b/tests/test_work_capacity_iso.py
@@ -12,8 +12,8 @@ def _expected_capacity(
     met: float | list[float],
 ) -> np.ndarray:
     """Calculate the expected work capacity based on WBGT and metabolic rate."""
-    wbgt_arr = np.array(wbgt)
-    met_arr = np.array(met)
+    wbgt_arr = np.asarray(wbgt)
+    met_arr = np.asarray(met)
     met_rest = 117.0
     wbgt_lim = 34.9 - met_arr / 46.0
     wbgt_lim_rest = 34.9 - met_rest / 46.0

--- a/tests/test_work_capacity_niosh.py
+++ b/tests/test_work_capacity_niosh.py
@@ -7,8 +7,8 @@ from pythermalcomfort.models.work_capacity_niosh import work_capacity_niosh
 
 def _expected_capacity(wbgt, met) -> np.ndarray:
     """Calculate the expected work capacity based on WBGT and metabolic rate."""
-    wbgt_arr = np.array(wbgt)
-    met_arr = np.array(met)
+    wbgt_arr = np.asarray(wbgt)
+    met_arr = np.asarray(met)
     met_rest = 117.0
     wbgt_lim = 56.7 - 11.5 * np.log10(met_arr)
     wbgt_lim_rest = 56.7 - 11.5 * np.log10(met_rest)


### PR DESCRIPTION
- Replace all np.array() calls with np.asarray() across the entire codebase
- np.asarray() avoids unnecessary copying when input is already a numpy array
- Improves memory efficiency and performance
- Affects all model functions, utilities, and test files
- Maintains full backward compatibility