### PR TITLE
Fix/sports heat stress risk scale

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "3.9.1"
+current_version = "3.9.2"
 commit = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-3.9.2 (2026-04-13)
+3.9.2 (2026-04-14)
 ------------------
 
 * Updated `sports_heat_stress_risk` so `risk_level_interpolated` now uses `1.0-4.0` instead of `0.0-3.0`.
+* Updated `sports_heat_stress_risk` to enforce the sport-specific minimum air speed (`sport.vr`).
 
 3.9.1 (2026-02-25)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.9.2 (2026-04-13)
+------------------
+
+* Updated `sports_heat_stress_risk` so `risk_level_interpolated` now uses `1.0-4.0` instead of `0.0-3.0`.
+
 3.9.1 (2026-02-25)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ project = "pythermalcomfort"
 year = "2025"
 author = "Federico Tartarini"
 project_copyright = f"{year}, {author}"
-version = release = "3.9.1"
+version = release = "3.9.2"
 
 autodoc_typehints = "none"
 pygments_style = "trac"

--- a/pythermalcomfort/__init__.py
+++ b/pythermalcomfort/__init__.py
@@ -4,4 +4,4 @@ This package provides comprehensive tools for calculating thermal comfort indice
 heat/cold stress metrics, and thermophysiological responses using multiple models.
 """
 
-__version__: str = "3.9.1"
+__version__: str = "3.9.2"

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -1256,6 +1256,8 @@ class SportsHeatStressInputs(BaseInputs):
         Relative humidity in percent (%). Values must be in the interval [0, 100].
     vr : float or array-like
         Relative air speed in metres per second (m/s). Values must be non-negative.
+        Values lower than ``sport.vr`` are accepted and set to ``sport.vr`` by
+        :func:`pythermalcomfort.models.sports_heat_stress_risk.sports_heat_stress_risk`.
     sport : _SportsValues
         Sport-specific parameters. Use one of the entries from
         :class:`pythermalcomfort.models.sports_heat_stress_risk.Sports` (e.g. ``Sports.RUNNING``).

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -1053,8 +1053,8 @@ class SportsHeatStressRisk(AutoStrMixin):
     Attributes
     ----------
     risk_level_interpolated : float or list of floats
-        Interpolated risk level (0.0-3.0), [dimensionless].
-        Risk levels: 0-1 = low, 1-2 = moderate, 2-3 = high, 3+ = extreme.
+        Interpolated risk level (1.0-4.0), [dimensionless].
+        Risk levels: 1-<2 = low, 2-<3 = moderate, 3-<4 = high, 4 = extreme.
     t_medium : float or list of floats
         Temperature threshold for medium risk level, [°C].
     t_high : float or list of floats

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -112,12 +112,14 @@ def sports_heat_stress_risk(
     rh : float or list of float
         Relative humidity [%].
     vr : float or list of float
-        Relative air speed [m/s].
+        Relative air speed [m/s]. Values lower than ``sport.vr`` are set to
+        ``sport.vr`` before the risk calculation.
     sport : _SportsValues
         Sport-specific activity dataclass with fields ``clo`` (clothing insulation),
-        ``met`` (metabolic rate), ``vr`` (relative air speed), and ``duration`` (activity duration).
-        Use one of the predefined entries from the :py:class:`Sports` class, e.g., ``Sports.RUNNING``,
-        ``Sports.SOCCER``, ``Sports.TENNIS``, etc.
+        ``met`` (metabolic rate), ``vr`` (minimum relative air speed),
+        and ``duration`` (activity duration). Use one of the predefined entries from
+        the :py:class:`Sports` class, e.g., ``Sports.RUNNING``, ``Sports.SOCCER``,
+        ``Sports.TENNIS``, etc.
 
     Returns
     -------
@@ -146,27 +148,29 @@ def sports_heat_stress_risk(
 
         # Example 1: Single condition for running
         result = sports_heat_stress_risk(
-            tdb=35, tr=35, rh=40, vr=0.1, sport=Sports.RUNNING
+            tdb=35, tr=35, rh=40, vr=2.0, sport=Sports.RUNNING
         )
-        print(result.risk_level_interpolated)  # 4.0 (Extreme risk)
-        print(result.t_medium)  # 23.0 (Temperature threshold for medium risk)
-        print(result.t_high)  # 25.0 (Temperature threshold for high risk)
-        print(result.t_extreme)  # 28.6 (Temperature threshold for extreme risk)
-        print(result.recommendation)  # "Consider suspending play"
+        print(result.risk_level_interpolated)  # 2.1 (Medium risk)
+        print(result.t_medium)  # 34.5 (Temperature threshold for medium risk)
+        print(result.t_high)  # 39.0 (Temperature threshold for high risk)
+        print(result.t_extreme)  # 41.6 (Temperature threshold for extreme risk)
+        print(
+            result.recommendation
+        )  # "Increase frequency and/or duration of rest breaks"
 
         # Example 2: Array inputs for multiple conditions
         result = sports_heat_stress_risk(
             tdb=[30, 35, 40],
             tr=[30, 35, 40],
             rh=[50, 50, 50],
-            vr=[0.5, 0.5, 0.5],
+            vr=[1.0, 1.0, 1.5],
             sport=Sports.SOCCER,
         )
         print(result.risk_level_interpolated)  # Array of risk levels
 
         # Example 3: Different sports
         result_tennis = sports_heat_stress_risk(
-            tdb=33, tr=70, rh=60, vr=0.1, sport=Sports.TENNIS
+            tdb=33, tr=70, rh=60, vr=0.75, sport=Sports.TENNIS
         )
         result_cycling = sports_heat_stress_risk(
             tdb=33, tr=70, rh=60, vr=3.0, sport=Sports.CYCLING
@@ -181,6 +185,7 @@ def sports_heat_stress_risk(
     tr = np.asarray(inputs.tr, dtype=float)
     rh = np.asarray(inputs.rh, dtype=float)
     vr = np.asarray(inputs.vr, dtype=float)
+    vr_effective = np.maximum(vr, sport.vr)
 
     # Vectorize the calculation function to handle arrays
     # Returns (risk_level_interpolated, t_medium, t_high, t_extreme, recommendation) for each input
@@ -188,7 +193,7 @@ def sports_heat_stress_risk(
         _calc_risk_single_value, otypes=[float, float, float, float, str]
     )
     risk_levels, t_mediums, t_highs, t_extremes, recommendations = vectorized_calc(
-        tdb=tdb, tr=tr, rh=rh, vr=vr, sport=sport
+        tdb=tdb, tr=tr, rh=rh, vr=vr_effective, sport=sport
     )
 
     return SportsHeatStressRisk(

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -112,8 +112,10 @@ def sports_heat_stress_risk(
     rh : float or list of float
         Relative humidity [%].
     vr : float or list of float
-        Relative air speed [m/s]. Values lower than ``sport.vr`` are set to
-        ``sport.vr`` before the risk calculation.
+        Relative air speed [m/s]. Please note that if the input vr is lower than
+        the self generated wind speed for each sport defined in the
+        :py:class:`Sports` class, then the sport.vr will be used for the
+        calculation.
     sport : _SportsValues
         Sport-specific activity dataclass with fields ``clo`` (clothing insulation),
         ``met`` (metabolic rate), ``vr`` (minimum relative air speed),

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -148,7 +148,7 @@ def sports_heat_stress_risk(
         result = sports_heat_stress_risk(
             tdb=35, tr=35, rh=40, vr=0.1, sport=Sports.RUNNING
         )
-        print(result.risk_level_interpolated)  # 3.0 (Extreme risk)
+        print(result.risk_level_interpolated)  # 4.0 (Extreme risk)
         print(result.t_medium)  # 23.0 (Temperature threshold for medium risk)
         print(result.t_high)  # 25.0 (Temperature threshold for high risk)
         print(result.t_extreme)  # 28.6 (Temperature threshold for extreme risk)
@@ -237,22 +237,22 @@ def _calc_risk_single_value(
     t_cr_extreme = 40  # core temperature for extreme risk
 
     if tdb < min_t_medium:
-        # Low risk - use default thresholds and risk level 0
+        # Low risk - use default thresholds and risk level 1
         return (
-            0.0,
+            1.0,
             min_t_medium,
             min_t_high,
             min_t_extreme,
-            _get_recommendation(0.0),
+            _get_recommendation(1.0),
         )
     if tdb > max_t_high:
-        # Extreme risk - use maximum thresholds and risk level 3
+        # Extreme risk - use maximum thresholds and risk level 4
         return (
-            3.0,
+            4.0,
             max_t_low,
             max_t_medium,
             max_t_high,
-            _get_recommendation(3.0),
+            _get_recommendation(4.0),
         )
 
     def calculate_threshold_water_loss(x):
@@ -347,13 +347,13 @@ def _calc_risk_single_value(
     risk_level_interpolated = np.nan
     # calculate the risk level with one decimal place
     if min_t_low <= tdb < t_medium:
-        risk_level_interpolated = (tdb - min_t_medium) / (t_medium - min_t_medium)
+        risk_level_interpolated = 1.0 + (tdb - min_t_medium) / (t_medium - min_t_medium)
     elif t_medium <= tdb < t_high:
-        risk_level_interpolated = 1.0 + (tdb - t_medium) / (t_high - t_medium)
+        risk_level_interpolated = 2.0 + (tdb - t_medium) / (t_high - t_medium)
     elif t_high <= tdb < t_extreme:
-        risk_level_interpolated = 2.0 + (tdb - t_high) / (t_extreme - t_high)
+        risk_level_interpolated = 3.0 + (tdb - t_high) / (t_extreme - t_high)
     elif tdb >= t_extreme:
-        risk_level_interpolated = 3.0
+        risk_level_interpolated = 4.0
 
     if np.isnan(risk_level_interpolated):
         raise ValueError("Risk level could not be determined due to NaN thresholds.")
@@ -379,7 +379,7 @@ def _get_recommendation(risk_level: float) -> str:
     Parameters
     ----------
     risk_level : float
-        Interpolated risk level (0.0-3.0).
+        Interpolated risk level (1.0-4.0).
 
     Returns
     -------
@@ -387,11 +387,11 @@ def _get_recommendation(risk_level: float) -> str:
         Evidence-based recommendation text for managing heat stress at the given
         risk level.
     """
-    if risk_level < 1.0:
+    if risk_level < 2.0:
         return "Increase hydration & modify clothing"
-    elif risk_level < 2.0:
-        return "Increase frequency and/or duration of rest breaks"
     elif risk_level < 3.0:
+        return "Increase frequency and/or duration of rest breaks"
+    elif risk_level < 4.0:
         return "Apply active cooling strategies"
     else:
         return "Consider suspending play"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(*names: str, encoding: str = "utf8") -> str:
 
 setup(
     name="pythermalcomfort",
-    version="3.9.1",
+    version="3.9.2",
     license="MIT",
     description=(
         "pythermalcomfort is a comprehensive toolkit for calculating "

--- a/tests/test_sports_heat_stress_risk.py
+++ b/tests/test_sports_heat_stress_risk.py
@@ -20,7 +20,7 @@ from pythermalcomfort.models.sports_heat_stress_risk import (
         # Very high temperature (extreme risk)
         (60, 20, 40, 2, Sports.MTB, 4.0),
         # Different sport - running at high temp (extreme risk)
-        (35, 35, 50, 0.5, Sports.RUNNING, 4.0),
+        (35, 35, 50, 0.5, Sports.RUNNING, 2.1),
     ],
 )
 def test_sports_heat_stress_risk_scalar(tdb, tr, rh, vr, sport, expected_risk):
@@ -38,6 +38,44 @@ def test_sports_heat_stress_risk_scalar(tdb, tr, rh, vr, sport, expected_risk):
     # Verify expected risk level - convert to float for comparison
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
     assert risk_value == pytest.approx(expected_risk, rel=0.01)
+
+
+def test_sports_heat_stress_risk_array_clamps_vr_to_sport_minimum():
+    """Test that array wind speed inputs are clamped elementwise to the sport minimum."""
+    tdb = np.array([30, 35, 40])
+    tr = np.array([30, 35, 40])
+    rh = np.array([40, 50, 60])
+    vr = np.array([0.5, 2.0, 2.5])
+    vr_effective = np.maximum(vr, Sports.RUNNING.vr)
+
+    result = sports_heat_stress_risk(tdb=tdb, tr=tr, rh=rh, vr=vr, sport=Sports.RUNNING)
+    expected = sports_heat_stress_risk(
+        tdb=tdb,
+        tr=tr,
+        rh=rh,
+        vr=vr_effective,
+        sport=Sports.RUNNING,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(result.risk_level_interpolated, dtype=float),
+        np.asarray(expected.risk_level_interpolated, dtype=float),
+    )
+    np.testing.assert_allclose(
+        np.asarray(result.t_medium, dtype=float),
+        np.asarray(expected.t_medium, dtype=float),
+    )
+    np.testing.assert_allclose(
+        np.asarray(result.t_high, dtype=float),
+        np.asarray(expected.t_high, dtype=float),
+    )
+    np.testing.assert_allclose(
+        np.asarray(result.t_extreme, dtype=float),
+        np.asarray(expected.t_extreme, dtype=float),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(result.recommendation), np.asarray(expected.recommendation)
+    )
 
 
 def test_sports_heat_stress_risk_array():
@@ -212,13 +250,12 @@ def test_sports_heat_stress_risk_recommendations():
     result_low = sports_heat_stress_risk(
         tdb=20, tr=20, rh=50, vr=0.5, sport=Sports.RUNNING
     )
-    # Convert numpy array to string for comparison
     assert "Increase hydration & modify clothing" == str(result_low.recommendation)
     assert 1.0 <= result_low.risk_level_interpolated < 2.0
 
     # Test medium risk (risk level 2.0-3.0)
     result_medium = sports_heat_stress_risk(
-        tdb=30, tr=30, rh=50, vr=0.5, sport=Sports.RUNNING
+        tdb=35, tr=34, rh=30, vr=0.5, sport=Sports.RUNNING
     )
     assert 2.0 <= result_medium.risk_level_interpolated < 3.0
     assert "Increase frequency and/or duration of rest breaks" == str(
@@ -227,14 +264,14 @@ def test_sports_heat_stress_risk_recommendations():
 
     # Test high risk (risk level 3.0-4.0)
     result_high = sports_heat_stress_risk(
-        tdb=35, tr=34, rh=30, vr=0.5, sport=Sports.RUNNING
+        tdb=40, tr=35, rh=30, vr=0.5, sport=Sports.RUNNING
     )
     assert 3.0 <= result_high.risk_level_interpolated < 4.0
     assert "Apply active cooling strategies" == str(result_high.recommendation)
 
     # Test medium risk near high boundary (risk level 2.0-3.0)
     result_high = sports_heat_stress_risk(
-        tdb=34, tr=34, rh=30, vr=0.5, sport=Sports.RUNNING
+        tdb=38, tr=38, rh=40, vr=0.5, sport=Sports.RUNNING
     )
     assert 2.0 <= result_high.risk_level_interpolated < 3.0
     assert "Increase frequency and/or duration of rest breaks" == str(

--- a/tests/test_sports_heat_stress_risk.py
+++ b/tests/test_sports_heat_stress_risk.py
@@ -12,15 +12,15 @@ from pythermalcomfort.models.sports_heat_stress_risk import (
     ("tdb", "tr", "rh", "vr", "sport", "expected_risk"),
     [
         # Moderate temperature
-        (33, 20, 40, 2, Sports.MTB, 0.8),
+        (33, 20, 40, 2, Sports.MTB, 1.8),
         # High temperature
-        (40, 20, 40, 2, Sports.MTB, 2.3),
+        (40, 20, 40, 2, Sports.MTB, 3.3),
         # Low temperature (low risk)
-        (10, 20, 40, 2, Sports.MTB, 0.0),
+        (10, 20, 40, 2, Sports.MTB, 1.0),
         # Very high temperature (extreme risk)
-        (60, 20, 40, 2, Sports.MTB, 3.0),
+        (60, 20, 40, 2, Sports.MTB, 4.0),
         # Different sport - running at high temp (extreme risk)
-        (35, 35, 50, 0.5, Sports.RUNNING, 3.0),
+        (35, 35, 50, 0.5, Sports.RUNNING, 4.0),
     ],
 )
 def test_sports_heat_stress_risk_scalar(tdb, tr, rh, vr, sport, expected_risk):
@@ -54,7 +54,7 @@ def test_sports_heat_stress_risk_array():
     # Verify array outputs - numpy.vectorize returns numpy arrays
     np.testing.assert_allclose(
         result.risk_level_interpolated,
-        [2.3, 2.3],
+        [3.3, 3.3],
         rtol=0.01,
         atol=0.01,
     )
@@ -93,7 +93,7 @@ def test_sports_heat_stress_risk_numpy_array():
 
     # Verify all values are valid
     for risk in result.risk_level_interpolated:
-        assert 0 <= risk <= 3
+        assert 1 <= risk <= 4
 
 
 def test_sports_heat_stress_risk_different_sports():
@@ -114,8 +114,8 @@ def test_sports_heat_stress_risk_different_sports():
     assert isinstance(result_running, SportsHeatStressRisk)
     assert isinstance(result_walking, SportsHeatStressRisk)
     # Both should return valid risk levels
-    assert 0 <= result_running.risk_level_interpolated <= 3
-    assert 0 <= result_walking.risk_level_interpolated <= 3
+    assert 1 <= result_running.risk_level_interpolated <= 4
+    assert 1 <= result_walking.risk_level_interpolated <= 4
 
 
 def test_sports_heat_stress_risk_invalid_inputs():
@@ -208,45 +208,45 @@ def test_sports_heat_stress_risk_dataclass_fields():
 
 def test_sports_heat_stress_risk_recommendations():
     """Test that recommendations are appropriate for different risk levels."""
-    # Test low risk (risk level < 1.0)
+    # Test low risk (risk level 1.0-2.0)
     result_low = sports_heat_stress_risk(
         tdb=20, tr=20, rh=50, vr=0.5, sport=Sports.RUNNING
     )
     # Convert numpy array to string for comparison
     assert "Increase hydration & modify clothing" == str(result_low.recommendation)
-    assert result_low.risk_level_interpolated < 1.0
+    assert 1.0 <= result_low.risk_level_interpolated < 2.0
 
-    # Test medium risk (risk level 1.0-2.0)
+    # Test medium risk (risk level 2.0-3.0)
     result_medium = sports_heat_stress_risk(
         tdb=30, tr=30, rh=50, vr=0.5, sport=Sports.RUNNING
     )
-    assert 1.0 <= result_medium.risk_level_interpolated < 2.0
+    assert 2.0 <= result_medium.risk_level_interpolated < 3.0
     assert "Increase frequency and/or duration of rest breaks" == str(
         result_medium.recommendation
     )
 
-    # Test high risk (risk level 2.0-3.0)
+    # Test high risk (risk level 3.0-4.0)
     result_high = sports_heat_stress_risk(
         tdb=35, tr=34, rh=30, vr=0.5, sport=Sports.RUNNING
     )
-    assert 2.0 <= result_high.risk_level_interpolated < 3.0
+    assert 3.0 <= result_high.risk_level_interpolated < 4.0
     assert "Apply active cooling strategies" == str(result_high.recommendation)
 
-    # Test medium risk near high boundary (risk level 1.0-2.0)
+    # Test medium risk near high boundary (risk level 2.0-3.0)
     result_high = sports_heat_stress_risk(
         tdb=34, tr=34, rh=30, vr=0.5, sport=Sports.RUNNING
     )
-    assert 1.0 <= result_high.risk_level_interpolated < 2.0
+    assert 2.0 <= result_high.risk_level_interpolated < 3.0
     assert "Increase frequency and/or duration of rest breaks" == str(
         result_high.recommendation
     )
 
-    # Test extreme risk (risk level >= 3.0)
+    # Test extreme risk (risk level = 4.0)
     result_extreme = sports_heat_stress_risk(
         tdb=50, tr=50, rh=50, vr=0.5, sport=Sports.RUNNING
     )
     assert "Consider suspending play" in str(result_extreme.recommendation)
-    assert result_extreme.risk_level_interpolated == pytest.approx(3.0, rel=1e-3)
+    assert result_extreme.risk_level_interpolated == pytest.approx(4.0, rel=1e-3)
 
 
 def test_sports_heat_stress_risk_array_recommendations():
@@ -304,17 +304,17 @@ def test_sports_heat_stress_risk_threshold_capping():
 
 def test_sports_heat_stress_risk_edge_temperature_ranges():
     """Test risk calculation at temperature boundary conditions."""
-    # Test very low temperature (should be low risk, risk_level = 0)
+    # Test very low temperature (should be low risk, risk_level = 1)
     result_very_low = sports_heat_stress_risk(
         tdb=15, tr=15, rh=50, vr=0.5, sport=Sports.RUNNING
     )
-    assert result_very_low.risk_level_interpolated == pytest.approx(0.0, abs=0.01)
+    assert result_very_low.risk_level_interpolated == pytest.approx(1.0, abs=0.01)
 
-    # Test very high temperature (should be extreme risk, risk_level = 3)
+    # Test very high temperature (should be extreme risk, risk_level = 4)
     result_very_high = sports_heat_stress_risk(
         tdb=50, tr=50, rh=50, vr=0.5, sport=Sports.RUNNING
     )
-    assert result_very_high.risk_level_interpolated == pytest.approx(3.0, abs=0.01)
+    assert result_very_high.risk_level_interpolated == pytest.approx(4.0, abs=0.01)
 
 
 def test_sports_heat_stress_risk_all_sports():
@@ -367,7 +367,7 @@ def test_sports_heat_stress_risk_all_sports():
         assert isinstance(result.risk_level_interpolated, (float, np.ndarray))
         # Convert to float for comparison
         risk_value = float(np.asarray(result.risk_level_interpolated).item())
-        assert 0 <= risk_value <= 3
+        assert 1 <= risk_value <= 4
         assert isinstance(result.t_medium, (float, np.ndarray))
         assert isinstance(result.t_high, (float, np.ndarray))
         assert isinstance(result.t_extreme, (float, np.ndarray))
@@ -406,7 +406,7 @@ def test_sports_heat_stress_risk_boundary_values(tdb, tr, rh, vr, sport):
     assert isinstance(result.risk_level_interpolated, (float, np.ndarray))
     # Convert to float for comparison
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
     assert isinstance(result.t_medium, (float, np.ndarray))
     assert isinstance(result.t_high, (float, np.ndarray))
     assert isinstance(result.t_extreme, (float, np.ndarray))
@@ -442,7 +442,7 @@ def test_sports_heat_stress_risk_very_large_wind_speed():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Extreme wind speed
     result = sports_heat_stress_risk(
@@ -450,7 +450,7 @@ def test_sports_heat_stress_risk_very_large_wind_speed():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
 
 def test_sports_heat_stress_risk_extreme_cold_temperatures():
@@ -461,8 +461,8 @@ def test_sports_heat_stress_risk_extreme_cold_temperatures():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    # Should be low risk (0) for extreme cold
-    assert risk_value == pytest.approx(0.0, abs=0.01)
+    # Should be low risk (1) for extreme cold
+    assert risk_value == pytest.approx(1.0, abs=0.01)
 
     # Extreme sub-zero temperature
     result = sports_heat_stress_risk(
@@ -470,7 +470,7 @@ def test_sports_heat_stress_risk_extreme_cold_temperatures():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(0.0, abs=0.01)
+    assert risk_value == pytest.approx(1.0, abs=0.01)
 
 
 def test_sports_heat_stress_risk_extreme_hot_temperatures():
@@ -479,14 +479,14 @@ def test_sports_heat_stress_risk_extreme_hot_temperatures():
     result = sports_heat_stress_risk(tdb=70, tr=70, rh=10, vr=0.5, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    # Should be extreme risk (3.0)
-    assert risk_value == pytest.approx(3.0, abs=0.01)
+    # Should be extreme risk (4.0)
+    assert risk_value == pytest.approx(4.0, abs=0.01)
 
     # Industrial environment extreme heat
     result = sports_heat_stress_risk(tdb=80, tr=80, rh=50, vr=0.1, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(3.0, abs=0.01)
+    assert risk_value == pytest.approx(4.0, abs=0.01)
 
 
 def test_sports_heat_stress_risk_zero_values():
@@ -495,13 +495,13 @@ def test_sports_heat_stress_risk_zero_values():
     result = sports_heat_stress_risk(tdb=0, tr=0, rh=0, vr=0, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Zero humidity and wind
     result = sports_heat_stress_risk(tdb=25, tr=25, rh=0, vr=0, sport=Sports.SOCCER)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
 
 def test_sports_heat_stress_risk_very_small_positive_values():
@@ -511,7 +511,7 @@ def test_sports_heat_stress_risk_very_small_positive_values():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Very small but valid humidity
     result = sports_heat_stress_risk(
@@ -519,7 +519,7 @@ def test_sports_heat_stress_risk_very_small_positive_values():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
 
 def test_sports_heat_stress_risk_float_precision_edge_cases():
@@ -570,7 +570,7 @@ def test_sports_heat_stress_risk_large_array():
     # Verify all values are valid
     for i in range(size):
         risk = float(np.asarray(result.risk_level_interpolated[i]).item())
-        assert 0 <= risk <= 3
+        assert 1 <= risk <= 4
         assert not np.isnan(risk)
 
 
@@ -580,13 +580,13 @@ def test_sports_heat_stress_risk_mixed_extreme_conditions():
     result = sports_heat_stress_risk(tdb=45, tr=50, rh=100, vr=0, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(3.0, abs=0.01)
+    assert risk_value == pytest.approx(4.0, abs=0.01)
 
     # High temp + low humidity + high wind (best cooling case)
     result = sports_heat_stress_risk(tdb=40, tr=40, rh=5, vr=10.0, sport=Sports.CYCLING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Cold + high humidity + high wind (hypothermia risk, but not heat stress)
     result = sports_heat_stress_risk(
@@ -594,7 +594,7 @@ def test_sports_heat_stress_risk_mixed_extreme_conditions():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(0.0, abs=0.01)
+    assert risk_value == pytest.approx(1.0, abs=0.01)
 
 
 def test_sports_heat_stress_risk_radiant_temperature_extremes():
@@ -603,19 +603,19 @@ def test_sports_heat_stress_risk_radiant_temperature_extremes():
     result = sports_heat_stress_risk(tdb=30, tr=70, rh=40, vr=0.5, sport=Sports.TENNIS)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Very low radiant temperature (shade)
     result = sports_heat_stress_risk(tdb=35, tr=20, rh=50, vr=0.5, sport=Sports.SOCCER)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Extreme radiant heat (hot surfaces)
     result = sports_heat_stress_risk(tdb=30, tr=80, rh=30, vr=1.0, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
 
 def test_sports_heat_stress_risk_negative_radiant_temperature():
@@ -624,7 +624,7 @@ def test_sports_heat_stress_risk_negative_radiant_temperature():
     result = sports_heat_stress_risk(tdb=20, tr=-5, rh=40, vr=0.5, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 0 <= risk_value <= 3
+    assert 1 <= risk_value <= 4
 
     # Very cold radiant surfaces
     result = sports_heat_stress_risk(
@@ -632,7 +632,7 @@ def test_sports_heat_stress_risk_negative_radiant_temperature():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(0.0, abs=0.01)
+    assert risk_value == pytest.approx(1.0, abs=0.01)
 
 
 def test_sports_heat_stress_risk_array_with_negative_wind_speeds():
@@ -721,10 +721,10 @@ def test_sports_heat_stress_risk_inf_values():
         result = sports_heat_stress_risk(
             tdb=-np.inf, tr=30, rh=50, vr=0.5, sport=Sports.WALKING
         )
-        # Should treat as extreme cold (risk = 0)
+        # Should treat as extreme cold (risk = 1)
         if isinstance(result, SportsHeatStressRisk):
             risk_value = float(np.asarray(result.risk_level_interpolated).item())
-            assert risk_value == pytest.approx(0.0, abs=0.01)
+            assert risk_value == pytest.approx(1.0, abs=0.01)
     except (ValueError, RuntimeError, Warning):
         # It's acceptable to raise an error for infinity
         pass
@@ -743,7 +743,7 @@ def test_sports_heat_stress_risk_stress_gradient():
         risks.append(risk_value)
 
     # Risk should generally increase with temperature
-    # (allowing for some flatness at the extremes where risk is capped at 0 or 3)
+    # (allowing for some flatness at the extremes where risk is capped at 1 or 4)
     for i in range(1, len(risks)):
         assert risks[i] >= risks[i - 1], (
             f"Risk decreased from {risks[i - 1]} to {risks[i]} when temperature increased from {temps[i - 1]} to {temps[i]}"


### PR DESCRIPTION
1. fix: bump version to 3.9.2 and update sports heat stress risk scale from 0.0-3.0 to 1.0-4.0
2. fix: enforce minimum sport air speed in sports_heat_stress_risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 3.9.2

* **New Features**
  * Updated sports heat stress risk scale from 0.0–3.0 to 1.0–4.0 with revised risk thresholds and recommendations.
  * Calculations now apply sport-specific minimum air speed thresholds.

* **Chores**
  * Version bumped to 3.9.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->