### PR TITLE
fix: add units to printed UTCI output

### DIFF
--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -681,7 +681,7 @@ class UTCI(AutoStrMixin):
         UTCI categorized in terms of thermal stress [Blazejczyk2013]_.
     """
 
-    _field_units: ClassVar[dict[str, str]] = {"utci": "C"}
+    _field_units: ClassVar[dict[str, str]] = {"utci": "°C"}
 
     utci: float | list[float]
     stress_category: str | list[str]

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import textwrap
 from dataclasses import dataclass, fields, is_dataclass
+from typing import ClassVar
 
 import numpy as np
 import numpy.typing as npt
@@ -10,6 +11,8 @@ from numpy._typing import NDArray
 
 
 class AutoStrMixin:
+    _field_units: ClassVar[dict[str, str]] = {}
+
     def __str__(self) -> str:
         """Pretty-print dataclass fields as aligned single-line 'name : value'.
 
@@ -23,6 +26,10 @@ class AutoStrMixin:
         MAX_STR_WIDTH = 80
         names = [f.name for f in fields(type(self))]
         values = [getattr(self, n) for n in names]
+        display_names = [
+            f"{name} [{self._field_units[name]}]" if name in self._field_units else name
+            for name in names
+        ]
 
         # Format values as strings, using comma separation for arrays/lists
         def value_to_str(val):
@@ -52,11 +59,11 @@ class AutoStrMixin:
 
         value_strs = [value_to_str(v) for v in values]
         # Find max name length for alignment
-        max_name_len = max(len(n) for n in names) if names else 0
+        max_name_len = max(len(n) for n in display_names) if display_names else 0
         # Compose lines with aligned colons
         lines = [
             f"{n.ljust(max_name_len)} : {v}"
-            for n, v in zip(names, value_strs, strict=True)
+            for n, v in zip(display_names, value_strs, strict=True)
         ]
         # Shorten each line to MAX_STR_WIDTH
         lines = [
@@ -673,6 +680,8 @@ class UTCI(AutoStrMixin):
     stress_category : str or list of strs
         UTCI categorized in terms of thermal stress [Blazejczyk2013]_.
     """
+
+    _field_units: ClassVar[dict[str, str]] = {"utci": "C"}
 
     utci: float | list[float]
     stress_category: str | list[str]

--- a/tests/test_classes_return.py
+++ b/tests/test_classes_return.py
@@ -85,6 +85,13 @@ def test_autostr_includes_field_units() -> None:
 
     output = str(result)
 
-    assert "utci [C]" in output
+    assert "utci [°C]" in output
     assert "stress_category" in output
     assert "stress_category [" not in output
+
+    scalar_output = str(UTCI(utci=24.6, stress_category="no thermal stress"))
+
+    assert "utci [°C]" in scalar_output
+    assert "24.6" in scalar_output
+    assert "[24.6]" not in scalar_output
+    assert "stress_category [" not in scalar_output

--- a/tests/test_classes_return.py
+++ b/tests/test_classes_return.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 
 # Import the AutoStrMixin class
-from pythermalcomfort.classes_return import AutoStrMixin
+from pythermalcomfort.classes_return import UTCI, AutoStrMixin
 
 
 @dataclass(repr=False)
@@ -74,3 +74,17 @@ def test_autostr_getitem_method_key_error() -> None:
     obj = TestDataClass(field1=42, field2="test", field3=[1, 2, 3])
     with pytest.raises(KeyError):
         _ = obj["non_existent"]
+
+
+def test_autostr_includes_field_units() -> None:
+    """Test that AutoStrMixin includes field units when defined."""
+    result = UTCI(
+        utci=[24.6, 40.6],
+        stress_category=["no thermal stress", "very strong heat stress"],
+    )
+
+    output = str(result)
+
+    assert "utci [C]" in output
+    assert "stress_category" in output
+    assert "stress_category [" not in output


### PR DESCRIPTION
## Summary

This PR addresses #295 by adding unit labels to printed result outputs when field units are defined.

Currently, UTCI printed output shows the field name without a unit. This PR adds a lightweight `_field_units` mapping to `AutoStrMixin`, so result classes can define units for specific printed fields.

For UTCI, the printed output now includes:

```text
utci [°C]
```

while non-numeric category fields such as `stress_category` remain unchanged.

## Changes

- Added `_field_units` support to `AutoStrMixin`.
- Updated printed field names to include units when defined.
- Added the UTCI unit mapping for the `utci` field.
- Added a test to verify that `utci [C]` appears in the printed output.

## Tests

I ran the following checks locally:

```bash
pipenv run python -m pytest tests/test_classes_return.py -q
pipenv run python -m pytest -k utci
pipenv run ruff check --fix pythermalcomfort tests
pipenv run ruff format pythermalcomfort tests
pipenv run python -m pytest -q
```

Results:

```text
300 passed, 1 xfailed, 7 warnings
```

Closes #295.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Result objects now automatically display unit annotations for applicable fields in their string representations, enhancing clarity when viewing thermal comfort outputs. Temperature and other relevant values now include unit labels (such as "[C]" for Celsius) to provide better context at a glance.

* **Tests**
  * Added test coverage verifying unit annotation formatting displays correctly in result outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->