### PR TITLE
Fix UTCI stress category for IP units

### DIFF
--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -120,6 +120,9 @@ def utci(
         all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
         utci_approx = np.where(all_valid, utci_approx, np.nan)
 
+    # Stress-category thresholds are in °C; keep the SI value before IP conversion.
+    utci_si = utci_approx
+
     if units.upper() == Units.IP.value:
         utci_approx = units_converter(
             tmp=utci_approx,
@@ -141,10 +144,11 @@ def utci(
 
     if round_output:
         utci_approx = np.round(utci_approx, 1)
+        utci_si = np.round(utci_si, 1)
 
     return UTCI(
         utci=utci_approx,
-        stress_category=mapping(utci_approx, stress_categories),
+        stress_category=mapping(utci_si, stress_categories),
     )
 
 

--- a/tests/test_utci.py
+++ b/tests/test_utci.py
@@ -28,3 +28,74 @@ def test_utci_optimized() -> None:
         np.around(_utci_optimized([25, 27], 1, 1, 1.5), 2),
         [24.73, 26.57],
     )
+
+
+def test_utci_ip_uses_si_thresholds_for_stress_category() -> None:
+    """Test that IP stress categories use the underlying SI UTCI value."""
+    result = utci(tdb=77, tr=77, v=3.28084, rh=50, units="IP")
+
+    assert result.utci == 76.4
+    assert result.stress_category == "no thermal stress"
+
+
+def test_utci_ip_vector_stress_category() -> None:
+    """Test that IP vector stress categories use SI UTCI values."""
+    result = utci(
+        tdb=[77, 104],
+        tr=[77, 104],
+        v=[3.28084, 3.28084],
+        rh=[50, 50],
+        units="IP",
+    )
+
+    np.testing.assert_allclose(result.utci, [76.4, 110.7])
+    np.testing.assert_array_equal(
+        result.stress_category,
+        ["no thermal stress", "very strong heat stress"],
+    )
+
+
+def test_utci_stress_category_uses_rounded_si_value_by_default() -> None:
+    """Test that default SI category mapping preserves rounded-output behavior."""
+    rounded = utci(tdb=26.24, tr=26.24, v=1, rh=50)
+    unrounded = utci(tdb=26.24, tr=26.24, v=1, rh=50, round_output=False)
+
+    assert rounded.utci == 26.0
+    assert rounded.stress_category == "no thermal stress"
+    assert unrounded.utci > 26.0
+    assert unrounded.stress_category == "moderate heat stress"
+
+
+def test_utci_ip_stress_category_uses_unrounded_si_value_when_not_rounding() -> None:
+    """Test that unrounded IP output maps categories from unrounded SI values."""
+    result = utci(
+        tdb=79.232,
+        tr=79.232,
+        v=3.28084,
+        rh=50,
+        units="IP",
+        round_output=False,
+    )
+
+    assert result.utci > 78.8
+    assert result.stress_category == "moderate heat stress"
+
+
+def test_utci_ip_out_of_range_stress_category_is_nan() -> None:
+    """Test that out-of-range IP inputs produce NaN stress categories."""
+    result = utci(tdb=1000, tr=1000, v=3.28084, rh=50, units="IP")
+
+    assert np.isnan(result.utci).item()
+    assert np.isnan(result.stress_category).item()
+
+    vector_result = utci(
+        tdb=[77, 1000],
+        tr=[77, 1000],
+        v=[3.28084, 3.28084],
+        rh=[50, 50],
+        units="IP",
+    )
+
+    np.testing.assert_allclose(vector_result.utci, [76.4, np.nan], equal_nan=True)
+    assert vector_result.stress_category[0] == "no thermal stress"
+    assert np.isnan(vector_result.stress_category[1])


### PR DESCRIPTION
Fixes #319.

Summary:
- Keep UTCI stress-category mapping in Celsius before converting the returned UTCI value to IP units.
- Preserve the existing rounded-output behavior for SI categories when round_output=True.
- Add regression coverage for scalar IP, vector IP, boundary rounding behavior, round_output=False, and out-of-range IP inputs.

Tests:
- .venv/bin/ruff check pythermalcomfort/models/utci.py tests/test_utci.py
- .venv/bin/ruff format --check pythermalcomfort/models/utci.py tests/test_utci.py
- .venv/bin/pytest tests/test_utci.py