### PR TITLE
docs: align dependency docs with setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,8 @@ Requirements
 ============
 
 - Python 3.10+
-- NumPy, SciPy, pandas (installed automatically)
-- Optional: Matplotlib or other plotting libraries for visualizations
+- NumPy, SciPy, Numba, setuptools (installed automatically)
+- Optional: pandas, Matplotlib, or other plotting libraries for examples and visualizations
 
 Quick Start
 ===========

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,7 +74,8 @@ Runtime dependencies (installed automatically via pip):
 
 - numpy
 - scipy
-- pandas
+- numba
+- setuptools
 
 Development extras (used by maintainers and contributors):
 
@@ -84,6 +85,11 @@ Development extras (used by maintainers and contributors):
 - pytest (testing)
 
 If you installed via ``pip install -e .[dev]`` these will be installed for you.
+
+Some docstring examples and notebooks also use ``pandas`` and
+``matplotlib``. These are not required to use the package and are not
+installed by ``pip install pythermalcomfort``; install them only if you
+want to run those examples.
 
 Verifying the installation
 ==========================


### PR DESCRIPTION
## Summary

- Align the dependency lists in `README.rst` and `docs/installation.rst` with `setup.py` `install_requires`: `numpy`, `scipy`, `numba`, and `setuptools`.
- Move `pandas` and `matplotlib` to optional wording for examples, notebooks, tests, and visualisations.
- Keep this as a docs-only change. It does not change `setup.py` or install behaviour.

Refs #305.

## Test plan

- [x] `git diff --check origin/development..HEAD`
- [x] `.venv/bin/pytest tests/test_utilities.py`
- [x] Checked the documented runtime list against `setup.py` `install_requires`.