### PR TITLE
test: drive wind_chill_temperature tests from shared validation table

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ class Urls(Enum):
     USE_FANS_HEATWAVES = "ts_use_fans_heatwaves.json"
     UTCI = "ts_utci.json"
     WIND_CHILL = "ts_wind_chill.json"
+    WIND_CHILL_TEMPERATURE = "ts_wind_chill_temperature.json"
     PET_STEADY = "ts_pet_steady.json"
     DISCOMFORT_INDEX = "ts_discomfort_index.json"
 

--- a/tests/test_wind_chill_temperature.py
+++ b/tests/test_wind_chill_temperature.py
@@ -2,59 +2,67 @@ import numpy as np
 import pytest
 
 from pythermalcomfort.models.wind_chill_temperature import wind_chill_temperature
+from tests.conftest import Urls, retrieve_reference_table, validate_result
+
+
+def test_wind_chill_temperature(get_test_url, retrieve_data) -> None:
+    """Test the wind_chill_temperature model against the shared validation table."""
+    reference_table = retrieve_reference_table(
+        get_test_url,
+        retrieve_data,
+        Urls.WIND_CHILL_TEMPERATURE.name,
+    )
+    tolerance = reference_table["tolerance"]
+
+    for entry in reference_table["data"]:
+        inputs = entry["inputs"]
+        outputs = entry["outputs"]
+        result = wind_chill_temperature(**inputs)
+
+        validate_result(result, outputs, tolerance)
 
 
 class TestWct:
-    """Test cases for the wind chill temperature (WCT) model."""
+    """Test cases for the wind chill temperature (WCT) model not covered by the validation table."""
 
-    # TODO this tests are not synced with comf R
-
-    def test_wct_results(self) -> None:
-        """Test that the function calculates WCT correctly for various inputs."""
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=5).wct, -24.3, atol=0.1)
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=15).wct, -29.1, atol=0.1)
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=60).wct, -36.5, atol=0.1)
-
-    # Calculate WCT correctly for single float inputs of temperature and wind speed
     def test_wct_single_float_inputs(self) -> None:
-        """Test that the function calculates WCT correctly for single float values of tdb and v."""
-        # Test with single float values
+        """Test that scalar inputs produce a scalar float result."""
         result = wind_chill_temperature(tdb=-5.0, v=5.5)
 
-        # Expected value calculated using the formula:
-        # 13.12 + 0.6215 * tdb - 11.37 * v**0.16 + 0.3965 * tdb * v**0.16
-        expected = -7.5
-
         assert isinstance(result.wct, float)
-        assert round(result.wct, 1) == expected
+        assert round(result.wct, 1) == -7.5
 
-    # Handle empty lists for temperature and wind speed inputs
     def test_wct_empty_lists(self) -> None:
-        """Test that the function handles empty lists for tdb and v inputs."""
-        # Test with empty lists
+        """Test that empty list inputs return an empty array."""
         assert np.allclose(
             wind_chill_temperature(tdb=[], v=[]).wct, np.asarray([]), equal_nan=True
         )
 
-    # Calculate WCT correctly for lists of temperature and wind speed values
     def test_wct_list_inputs(self) -> None:
-        """Test that the function calculates WCT correctly for lists of tdb and v values."""
-        # Test with list of values
+        """Test that list inputs are broadcast and return an ndarray."""
         result = wind_chill_temperature(
             tdb=[-5.0, -10.0], v=[5.5, 10.0], round_output=True
         )
 
-        # Expected values calculated using the formula:
-        # 13.12 + 0.6215 * tdb - 11.37 * v**0.16 + 0.3965 * tdb * v**0.16
-        expected = [-7.5, -15.3]
-
         assert isinstance(result.wct, np.ndarray)
-        assert np.allclose(result.wct, expected, atol=0.1)
+        assert np.allclose(result.wct, [-7.5, -15.3], atol=0.1)
 
-    # Handle non-numeric input values
+    def test_wct_round_output_false_returns_unrounded(self) -> None:
+        """Test that round_output=False bypasses rounding and returns the formula output.
+
+        The shared validation table tolerates 0.1 K on wct, which is wider than the
+        rounding step itself, so a regression that ignored round_output=False and
+        returned -7.5 would still pass the fixture row. This local assertion pins
+        the unrounded value tightly.
+        """
+        result = wind_chill_temperature(tdb=-5.0, v=5.5, round_output=False)
+
+        expected = 13.12 + 0.6215 * -5.0 - 11.37 * 5.5**0.16 + 0.3965 * -5.0 * 5.5**0.16
+        assert result.wct == pytest.approx(expected, abs=1e-9)
+        assert result.wct != -7.5
+
     def test_wct_non_numeric_inputs(self) -> None:
-        """Function raises a TypeError if non-numeric values are inputs."""
-        # Test with non-numeric values for tdb and v
+        """Test that non-numeric inputs raise a TypeError."""
         with pytest.raises(TypeError):
             wind_chill_temperature(tdb="invalid", v=5.5)
 


### PR DESCRIPTION
Reads the scalar reference cases for `wind_chill_temperature` from `ts_wind_chill_temperature.json`, replacing the three local scalar assertions with the shared validation-table pattern used by the existing fixture-driven tests.

Keeps local checks for scalar/array return shape, empty-list input, non-numeric `TypeError`, and a tight `round_output=False` assertion because the shared `wct` tolerance is 0.1 K. No model source is touched.

Cross-ref: FedericoTartarini/validation-data-comfort-models#10.
