### PR TITLE
Restrict compliance attribute to ASHRAE model and improve documentation

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "3.9.7"
+current_version = "3.9.8"
 commit = true
 tag = true
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:rc(?P<pre_n>\\d+))?"

--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,8 @@ Requirements
 ============
 
 - Python 3.10+
-- NumPy, SciPy, pandas (installed automatically)
-- Optional: Matplotlib or other plotting libraries for visualizations
+- NumPy, SciPy, Numba, setuptools (installed automatically)
+- Optional: pandas, Matplotlib, or other plotting libraries for examples and visualizations
 
 Quick Start
 ===========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ project = "pythermalcomfort"
 year = "2025"
 author = "Federico Tartarini"
 project_copyright = f"{year}, {author}"
-version = release = "3.9.7"
+version = release = "3.9.8"
 
 autodoc_typehints = "none"
 pygments_style = "trac"

--- a/docs/documentation/models.rst
+++ b/docs/documentation/models.rst
@@ -259,8 +259,7 @@ ASHRAE 55 - PMV and PPD
 
 .. autofunction:: pythermalcomfort.models.pmv_ppd_ashrae.pmv_ppd_ashrae
 
-.. autoclass:: pythermalcomfort.classes_return.PMVPPD
-    :noindex:
+.. autoclass:: pythermalcomfort.classes_return.PMVPPDAshrae
     :members:
 
 Adaptive Predicted Mean Vote (aPMV)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,7 +74,8 @@ Runtime dependencies (installed automatically via pip):
 
 - numpy
 - scipy
-- pandas
+- numba
+- setuptools
 
 Development extras (used by maintainers and contributors):
 
@@ -84,6 +85,11 @@ Development extras (used by maintainers and contributors):
 - pytest (testing)
 
 If you installed via ``pip install -e .[dev]`` these will be installed for you.
+
+Some docstring examples and notebooks also use ``pandas`` and
+``matplotlib``. These are not required to use the package and are not
+installed by ``pip install pythermalcomfort``; install them only if you
+want to run those examples.
 
 Verifying the installation
 ==========================

--- a/pythermalcomfort/__init__.py
+++ b/pythermalcomfort/__init__.py
@@ -4,4 +4,4 @@ This package provides comprehensive tools for calculating thermal comfort indice
 heat/cold stress metrics, and thermophysiological responses using multiple models.
 """
 
-__version__: str = "3.9.7"
+__version__: str = "3.9.8"

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -1082,9 +1082,9 @@ class ScaleWindSpeedLogInputs(BaseInputs):
         self,
         v_z1,
         z2,
-        z1: float | int | np.ndarray | list = 10.0,
-        z0: float | int | np.ndarray | list = 0.01,
-        d: float | int | np.ndarray | list = 0.0,
+        z1: NumericInput = 10.0,
+        z0: NumericInput = 0.01,
+        d: NumericInput = 0.0,
     ):
         super().__init__(
             v_z1=v_z1,
@@ -1203,10 +1203,10 @@ class SportsHeatStressInputs(BaseInputs):
 
     def __init__(
         self,
-        tdb: float | int | np.ndarray | list,
-        tr: float | int | np.ndarray | list,
-        rh: float | int | np.ndarray | list,
-        vr: float | int | np.ndarray | list,
+        tdb: NumericInput,
+        tr: NumericInput,
+        rh: NumericInput,
+        vr: NumericInput,
         sport: _SportsValues,
     ):
         # Store sport before calling super().__init__() as it's not a BaseInputs field

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -12,6 +12,13 @@ import numpy as np
 
 from pythermalcomfort.utilities import Postures, Sex, Units, validate_type
 
+NumericInput = float | int | np.ndarray | list
+_NUMERIC_TYPES = NumericInput.__args__
+
+
+def numeric_field(default=None):
+    return field(default=default, metadata={"types": _NUMERIC_TYPES})
+
 
 class WorkIntensity(str, Enum):
     """Enumeration for work intensity levels."""
@@ -26,49 +33,23 @@ class BaseInputs:
     """Base inputs with metadata-driven validation."""
 
     a_coefficient: float | int = field(default=None, metadata={"types": (float, int)})
-    age: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    age: NumericInput = numeric_field()
     airspeed_control: bool = field(default=True, metadata={"is_bool": True})
-    asw: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    body_surface_area: float | int | np.ndarray | list = field(
-        default=1.8258, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    clo: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    d: float | int | np.ndarray | list = field(
-        default=0, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    asw: NumericInput = numeric_field()
+    body_surface_area: NumericInput = numeric_field(1.8258)
+    clo: NumericInput = numeric_field()
+    d: NumericInput = numeric_field(0)
     duration: int = field(default=None, metadata={"types": (int, np.ndarray)})
     e_coefficient: float | int = field(default=None, metadata={"types": (float, int)})
-    f_bes: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    f_svv: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    floor_reflectance: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    height: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    f_bes: NumericInput = numeric_field()
+    f_svv: NumericInput = numeric_field()
+    floor_reflectance: NumericInput = numeric_field()
+    height: NumericInput = numeric_field()
     limit_inputs: bool = field(default=True, metadata={"is_bool": True})
-    max_skin_blood_flow: float | int | np.ndarray | list = field(
-        default=80, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    max_sweating: float | int | np.ndarray | list = field(
-        default=500, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    met: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    p_atm: float | int | np.ndarray | list = field(
-        default=101325, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    max_skin_blood_flow: NumericInput = numeric_field(80)
+    max_sweating: NumericInput = numeric_field(500)
+    met: NumericInput = numeric_field()
+    p_atm: NumericInput = numeric_field(101325)
     position: str | np.ndarray | list = field(
         default=None,
         metadata={
@@ -89,102 +70,44 @@ class BaseInputs:
             ]
         },
     )
-    q: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    rh: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    q: NumericInput = numeric_field()
+    rh: NumericInput = numeric_field()
     round_output: bool = field(default=True, metadata={"is_bool": True})
     sex: str | np.ndarray | list = field(
         default=None, metadata={"allowed": [Sex.male.value, Sex.female.value]}
     )
-    sharp: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    sol_altitude: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    sol_radiation_dir: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    sol_radiation_global: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    sol_transmittance: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    t_re: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    t_running_mean: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    t_sk: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    tdb: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    tg: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    thickness_quilt: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    tout: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    tr: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    twb: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    sharp: NumericInput = numeric_field()
+    sol_altitude: NumericInput = numeric_field()
+    sol_radiation_dir: NumericInput = numeric_field()
+    sol_radiation_global: NumericInput = numeric_field()
+    sol_transmittance: NumericInput = numeric_field()
+    t_re: NumericInput = numeric_field()
+    t_running_mean: NumericInput = numeric_field()
+    t_sk: NumericInput = numeric_field()
+    tdb: NumericInput = numeric_field()
+    tg: NumericInput = numeric_field()
+    thickness_quilt: NumericInput = numeric_field()
+    tout: NumericInput = numeric_field()
+    tr: NumericInput = numeric_field()
+    twb: NumericInput = numeric_field()
     units: str = field(default=Units.SI.value)
-    v: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    v_ankle: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    v_z1: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    vapor_pressure: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    vertical_tmp_grad: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    vr: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    w_max: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    wbgt: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    weight: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    v: NumericInput = numeric_field()
+    v_ankle: NumericInput = numeric_field()
+    v_z1: NumericInput = numeric_field()
+    vapor_pressure: NumericInput = numeric_field()
+    vertical_tmp_grad: NumericInput = numeric_field()
+    vr: NumericInput = numeric_field()
+    w_max: NumericInput = numeric_field()
+    wbgt: NumericInput = numeric_field()
+    weight: NumericInput = numeric_field()
     with_solar_load: bool = field(default=False, metadata={"is_bool": True})
     work_intensity: str | Enum = field(
         default=None, metadata={"allowed": [i.value for i in WorkIntensity]}
     )
-    z0: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    z1: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    z2: float | int | np.ndarray | list = field(
-        default=None, metadata={"types": (float, int, np.ndarray, list)}
-    )
-    wme: float | int | np.ndarray | list = field(
-        default=0, metadata={"types": (float, int, np.ndarray, list)}
-    )
+    z0: NumericInput = numeric_field()
+    z1: NumericInput = numeric_field()
+    z2: NumericInput = numeric_field()
+    wme: NumericInput = numeric_field(0)
 
     def __post_init__(self) -> None:
         """Validate and normalize fields using metadata declared on each field."""
@@ -1244,7 +1167,8 @@ class ScaleWindSpeedLogInputs(BaseInputs):
 
 @dataclass
 class SportsHeatStressInputs(BaseInputs):
-    """Inputs for :func:`pythermalcomfort.models.sports_heat_stress_risk.sports_heat_stress_risk`.
+    """Inputs for
+    :func:`pythermalcomfort.models.sports_heat_stress_risk.sports_heat_stress_risk`.
 
     Parameters
     ----------

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -441,7 +441,8 @@ class PMVPPDAshrae(PMVPPD):
         Predicted thermal sensation vote.
     compliance : bool or list of bools
         True if PMV is within the acceptable range (-0.5 < PMV < 0.5) according to
-        ASHRAE Standard 55-2023.
+        ASHRAE Standard 55-2023. When ``limit_inputs=True`` and any input is outside
+        the standard applicability limits, ``compliance`` will be ``nan``.
     """
 
     compliance: bool | list[bool]

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -419,15 +419,32 @@ class PMVPPD(AutoStrMixin):
         Predicted Percentage of Dissatisfied.
     tsv : str or list of strings
         Predicted thermal sensation vote.
-    compliance : bool or list of bools, optional
-        True if PMV is within the acceptable range (-0.5 < PMV < 0.5) according to
-        ASHRAE Standard 55-2023. Only returned by pmv_ppd_ashrae function.
     """
 
     pmv: float | list[float]
     ppd: float | list[float]
     tsv: float | list[float]
-    compliance: bool | list[bool] | None = None
+
+
+@dataclass(frozen=True, repr=False)
+class PMVPPDAshrae(PMVPPD):
+    """Dataclass to represent the Predicted Mean Vote (PMV) and Predicted Percentage of
+    Dissatisfied (PPD) calculated in accordance with ASHRAE Standard 55.
+
+    Attributes
+    ----------
+    pmv : float or list of floats
+        Predicted Mean Vote.
+    ppd : float or list of floats
+        Predicted Percentage of Dissatisfied.
+    tsv : str or list of strings
+        Predicted thermal sensation vote.
+    compliance : bool or list of bools
+        True if PMV is within the acceptable range (-0.5 < PMV < 0.5) according to
+        ASHRAE Standard 55-2023.
+    """
+
+    compliance: bool | list[bool]
 
 
 @dataclass(frozen=True, repr=False)

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -99,11 +99,11 @@ def pmv_ppd_ashrae(
 
     Returns
     -------
-    PMVPPD
+    PMVPPDAshrae
         A dataclass containing the Predicted Mean Vote and Predicted Percentage of
-        Dissatisfied. See :py:class:`~pythermalcomfort.classes_return.PMVPPD` for
+        Dissatisfied. See :py:class:`~pythermalcomfort.classes_return.PMVPPDAshrae` for
         more details. To access the `pmv`, `ppd`, `tsv`, and `compliance` values, use the corresponding
-        attributes of the returned `PMVPPD` instance, e.g., `result.pmv`, `result.compliance`.
+        attributes of the returned `PMVPPDAshrae` instance, e.g., `result.pmv`, `result.compliance`.
 
     Examples
     --------

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from pythermalcomfort.classes_input import PMVPPDInputs
-from pythermalcomfort.classes_return import PMVPPD
+from pythermalcomfort.classes_return import PMVPPDAshrae
 from pythermalcomfort.models._pmv_ppd_optimized import _pmv_ppd_optimized
 from pythermalcomfort.models.cooling_effect import cooling_effect
 from pythermalcomfort.shared_functions import _finalize_scalar_or_array, mapping
@@ -28,7 +28,7 @@ def pmv_ppd_ashrae(
     limit_inputs: bool = True,
     airspeed_control: bool = True,
     round_output: bool = True,
-) -> PMVPPD:
+) -> PMVPPDAshrae:
     """Return Predicted Mean Vote (PMV) and Predicted Percentage of Dissatisfied (PPD)
     calculated in accordance with the ASHRAE 55 Standard.
 
@@ -239,7 +239,7 @@ def pmv_ppd_ashrae(
         10: "Hot",
     }
 
-    return PMVPPD(
+    return PMVPPDAshrae(
         pmv=pmv_array,
         ppd=ppd_array,
         tsv=mapping(pmv_array, thermal_sensation),

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -120,6 +120,9 @@ def utci(
         all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
         utci_approx = np.where(all_valid, utci_approx, np.nan)
 
+    # Stress-category thresholds are in °C; keep the SI value before IP conversion.
+    utci_si = utci_approx
+
     if units.upper() == Units.IP.value:
         utci_approx = units_converter(
             tmp=utci_approx,
@@ -141,10 +144,11 @@ def utci(
 
     if round_output:
         utci_approx = np.round(utci_approx, 1)
+        utci_si = np.round(utci_si, 1)
 
     return UTCI(
         utci=utci_approx,
-        stress_category=mapping(utci_approx, stress_categories),
+        stress_category=mapping(utci_si, stress_categories),
     )
 
 

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -46,7 +46,7 @@ def utci(
         By default, if the inputs are outside the standard applicability limits the
         function returns nan. If False, returns UTCI values even if input values are
         outside the applicability limits of the model. The valid input ranges are
-        -50 < tdb [°C] < 50, tdb - 70 < tr [°C] < tdb + 30, and for 0.5 < v [m/s] < 17.0. Defaults to True.
+        -50 < tdb [°C] < 50, tdb - 30 < tr [°C] < tdb + 70, and for 0.5 < v [m/s] < 17.0. Defaults to True.
     round_output : bool, optional
         If True, rounds output value. If False, it does not round it. Defaults to True.
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(*names: str, encoding: str = "utf8") -> str:
 
 setup(
     name="pythermalcomfort",
-    version="3.9.7",
+    version="3.9.8",
     license="MIT",
     description=(
         "pythermalcomfort is a comprehensive toolkit for calculating "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ class Urls(Enum):
     USE_FANS_HEATWAVES = "ts_use_fans_heatwaves.json"
     UTCI = "ts_utci.json"
     WIND_CHILL = "ts_wind_chill.json"
+    WIND_CHILL_TEMPERATURE = "ts_wind_chill_temperature.json"
     PET_STEADY = "ts_pet_steady.json"
     DISCOMFORT_INDEX = "ts_discomfort_index.json"
 

--- a/tests/test_pmv_ppd_ashrae.py
+++ b/tests/test_pmv_ppd_ashrae.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pythermalcomfort.classes_return import PMVPPD
+from pythermalcomfort.classes_return import PMVPPDAshrae
 from pythermalcomfort.models import pmv_ppd_ashrae
 from pythermalcomfort.utilities import Models
 from tests.conftest import Urls, retrieve_reference_table, validate_result
@@ -100,7 +100,7 @@ class TestPmvPpd:
                 model=Models.ashrae_55_2023.value,
                 limit_inputs=False,
             ),
-            PMVPPD(
+            PMVPPDAshrae(
                 pmv=np.float64(4.48),
                 ppd=np.float64(100.0),
                 tsv=np.str_("Hot"),

--- a/tests/test_pmv_ppd_iso.py
+++ b/tests/test_pmv_ppd_iso.py
@@ -122,6 +122,19 @@ class TestPmvPpd:
             PMVPPD(pmv=np.float64(2.4), ppd=np.float64(91.0), tsv="Warm"),
         )
 
+    def test_no_compliance_attribute(self) -> None:
+        """Test that ISO result does not have a compliance attribute."""
+        result = pmv_ppd_iso(
+            tdb=25,
+            tr=25,
+            vr=0.1,
+            rh=50,
+            met=1.4,
+            clo=0.5,
+            model=Models.iso_7730_2005.value,
+        )
+        assert not hasattr(result, "compliance")
+
     def test_wrong_standard(self) -> None:
         """Test that the function raises ValueError for an unsupported standard."""
         with pytest.raises(ValueError):

--- a/tests/test_utci.py
+++ b/tests/test_utci.py
@@ -28,3 +28,74 @@ def test_utci_optimized() -> None:
         np.around(_utci_optimized([25, 27], 1, 1, 1.5), 2),
         [24.73, 26.57],
     )
+
+
+def test_utci_ip_uses_si_thresholds_for_stress_category() -> None:
+    """Test that IP stress categories use the underlying SI UTCI value."""
+    result = utci(tdb=77, tr=77, v=3.28084, rh=50, units="IP")
+
+    assert result.utci == 76.4
+    assert result.stress_category == "no thermal stress"
+
+
+def test_utci_ip_vector_stress_category() -> None:
+    """Test that IP vector stress categories use SI UTCI values."""
+    result = utci(
+        tdb=[77, 104],
+        tr=[77, 104],
+        v=[3.28084, 3.28084],
+        rh=[50, 50],
+        units="IP",
+    )
+
+    np.testing.assert_allclose(result.utci, [76.4, 110.7])
+    np.testing.assert_array_equal(
+        result.stress_category,
+        ["no thermal stress", "very strong heat stress"],
+    )
+
+
+def test_utci_stress_category_uses_rounded_si_value_by_default() -> None:
+    """Test that default SI category mapping preserves rounded-output behavior."""
+    rounded = utci(tdb=26.24, tr=26.24, v=1, rh=50)
+    unrounded = utci(tdb=26.24, tr=26.24, v=1, rh=50, round_output=False)
+
+    assert rounded.utci == 26.0
+    assert rounded.stress_category == "no thermal stress"
+    assert unrounded.utci > 26.0
+    assert unrounded.stress_category == "moderate heat stress"
+
+
+def test_utci_ip_stress_category_uses_unrounded_si_value_when_not_rounding() -> None:
+    """Test that unrounded IP output maps categories from unrounded SI values."""
+    result = utci(
+        tdb=79.232,
+        tr=79.232,
+        v=3.28084,
+        rh=50,
+        units="IP",
+        round_output=False,
+    )
+
+    assert result.utci > 78.8
+    assert result.stress_category == "moderate heat stress"
+
+
+def test_utci_ip_out_of_range_stress_category_is_nan() -> None:
+    """Test that out-of-range IP inputs produce NaN stress categories."""
+    result = utci(tdb=1000, tr=1000, v=3.28084, rh=50, units="IP")
+
+    assert np.isnan(result.utci).item()
+    assert np.isnan(result.stress_category).item()
+
+    vector_result = utci(
+        tdb=[77, 1000],
+        tr=[77, 1000],
+        v=[3.28084, 3.28084],
+        rh=[50, 50],
+        units="IP",
+    )
+
+    np.testing.assert_allclose(vector_result.utci, [76.4, np.nan], equal_nan=True)
+    assert vector_result.stress_category[0] == "no thermal stress"
+    assert np.isnan(vector_result.stress_category[1])

--- a/tests/test_wind_chill_temperature.py
+++ b/tests/test_wind_chill_temperature.py
@@ -2,59 +2,67 @@ import numpy as np
 import pytest
 
 from pythermalcomfort.models.wind_chill_temperature import wind_chill_temperature
+from tests.conftest import Urls, retrieve_reference_table, validate_result
+
+
+def test_wind_chill_temperature(get_test_url, retrieve_data) -> None:
+    """Test the wind_chill_temperature model against the shared validation table."""
+    reference_table = retrieve_reference_table(
+        get_test_url,
+        retrieve_data,
+        Urls.WIND_CHILL_TEMPERATURE.name,
+    )
+    tolerance = reference_table["tolerance"]
+
+    for entry in reference_table["data"]:
+        inputs = entry["inputs"]
+        outputs = entry["outputs"]
+        result = wind_chill_temperature(**inputs)
+
+        validate_result(result, outputs, tolerance)
 
 
 class TestWct:
-    """Test cases for the wind chill temperature (WCT) model."""
+    """Test cases for the wind chill temperature (WCT) model not covered by the validation table."""
 
-    # TODO this tests are not synced with comf R
-
-    def test_wct_results(self) -> None:
-        """Test that the function calculates WCT correctly for various inputs."""
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=5).wct, -24.3, atol=0.1)
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=15).wct, -29.1, atol=0.1)
-        assert np.isclose(wind_chill_temperature(tdb=-20, v=60).wct, -36.5, atol=0.1)
-
-    # Calculate WCT correctly for single float inputs of temperature and wind speed
     def test_wct_single_float_inputs(self) -> None:
-        """Test that the function calculates WCT correctly for single float values of tdb and v."""
-        # Test with single float values
+        """Test that scalar inputs produce a scalar float result."""
         result = wind_chill_temperature(tdb=-5.0, v=5.5)
 
-        # Expected value calculated using the formula:
-        # 13.12 + 0.6215 * tdb - 11.37 * v**0.16 + 0.3965 * tdb * v**0.16
-        expected = -7.5
-
         assert isinstance(result.wct, float)
-        assert round(result.wct, 1) == expected
+        assert round(result.wct, 1) == -7.5
 
-    # Handle empty lists for temperature and wind speed inputs
     def test_wct_empty_lists(self) -> None:
-        """Test that the function handles empty lists for tdb and v inputs."""
-        # Test with empty lists
+        """Test that empty list inputs return an empty array."""
         assert np.allclose(
             wind_chill_temperature(tdb=[], v=[]).wct, np.asarray([]), equal_nan=True
         )
 
-    # Calculate WCT correctly for lists of temperature and wind speed values
     def test_wct_list_inputs(self) -> None:
-        """Test that the function calculates WCT correctly for lists of tdb and v values."""
-        # Test with list of values
+        """Test that list inputs are broadcast and return an ndarray."""
         result = wind_chill_temperature(
             tdb=[-5.0, -10.0], v=[5.5, 10.0], round_output=True
         )
 
-        # Expected values calculated using the formula:
-        # 13.12 + 0.6215 * tdb - 11.37 * v**0.16 + 0.3965 * tdb * v**0.16
-        expected = [-7.5, -15.3]
-
         assert isinstance(result.wct, np.ndarray)
-        assert np.allclose(result.wct, expected, atol=0.1)
+        assert np.allclose(result.wct, [-7.5, -15.3], atol=0.1)
 
-    # Handle non-numeric input values
+    def test_wct_round_output_false_returns_unrounded(self) -> None:
+        """Test that round_output=False bypasses rounding and returns the formula output.
+
+        The shared validation table tolerates 0.1 K on wct, which is wider than the
+        rounding step itself, so a regression that ignored round_output=False and
+        returned -7.5 would still pass the fixture row. This local assertion pins
+        the unrounded value tightly.
+        """
+        result = wind_chill_temperature(tdb=-5.0, v=5.5, round_output=False)
+
+        expected = 13.12 + 0.6215 * -5.0 - 11.37 * 5.5**0.16 + 0.3965 * -5.0 * 5.5**0.16
+        assert result.wct == pytest.approx(expected, abs=1e-9)
+        assert result.wct != -7.5
+
     def test_wct_non_numeric_inputs(self) -> None:
-        """Function raises a TypeError if non-numeric values are inputs."""
-        # Test with non-numeric values for tdb and v
+        """Test that non-numeric inputs raise a TypeError."""
         with pytest.raises(TypeError):
             wind_chill_temperature(tdb="invalid", v=5.5)
 


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the pythermalcomfort codebase, focusing on type simplification, improved input handling, and clarifications in the API and documentation. The most significant changes include the introduction of a new `PMVPPDAshrae` dataclass for ASHRAE-compliant PMV/PPD results, a major refactor of numeric input type handling in model input classes, and updates to documentation and dependencies to reflect these changes.

**API and Model Output Improvements:**

* Introduced a new `PMVPPDAshrae` dataclass in `pythermalcomfort.classes_return` to represent ASHRAE-compliant PMV/PPD results, including a clear `compliance` attribute. The `pmv_ppd_ashrae` function and related documentation now use this new class instead of the generic `PMVPPD`. [[1]](diffhunk://#diff-e81f7a46d5456aded95e9adb110f84b43ce17b5f73cbf9814571a8822d69ce42L422-R448) [[2]](diffhunk://#diff-c9eaaaa5deeb6a659f26278ced75775ec00ebc888a95a814b201f306ff7d84d5L262-R262) [[3]](diffhunk://#diff-01ec9c79fbf186d163f6132f2d341d015d2a26b55379d66f4e4c6b18c3bafbc9L6-R6) [[4]](diffhunk://#diff-01ec9c79fbf186d163f6132f2d341d015d2a26b55379d66f4e4c6b18c3bafbc9L31-R31) [[5]](diffhunk://#diff-01ec9c79fbf186d163f6132f2d341d015d2a26b55379d66f4e4c6b18c3bafbc9L102-R106) [[6]](diffhunk://#diff-01ec9c79fbf186d163f6132f2d341d015d2a26b55379d66f4e4c6b18c3bafbc9L242-R242) [[7]](diffhunk://#diff-2ee31216252afc263ba16c837218b0120fb9731a3fffdec59468147d0c1f0666L4-R4)

* In the UTCI model, fixed the stress category mapping to always use the SI value before any unit conversion, ensuring correct results regardless of output units. [[1]](diffhunk://#diff-82ab8c35ebc5e8b32719c6b0a0c09de92b9cde7e6e486b9a61300e618f1102dfL49-R49) [[2]](diffhunk://#diff-82ab8c35ebc5e8b32719c6b0a0c09de92b9cde7e6e486b9a61300e618f1102dfR123-R125) [[3]](diffhunk://#diff-82ab8c35ebc5e8b32719c6b0a0c09de92b9cde7e6e486b9a61300e618f1102dfR147-R151)

**Input Handling and Type Simplification:**

* Refactored numeric input type declarations in `pythermalcomfort.classes_input.BaseInputs` and subclasses: introduced a `NumericInput` type alias and a `numeric_field` helper to reduce repetition and centralize type validation for fields accepting float, int, numpy arrays, or lists. Updated all relevant fields and constructors to use this new approach. [[1]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R15-R21) [[2]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5L29-R52) [[3]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5L92-R110) [[4]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5L1162-R1087) [[5]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5L1247-R1171) [[6]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5L1282-R1209)

**Documentation and Dependency Updates:**

* Updated documentation and example references to reflect the new `PMVPPDAshrae` class and clarify optional dependencies (e.g., pandas, matplotlib), as well as corrections to input parameter documentation for UTCI and other models. [[1]](diffhunk://#diff-c9eaaaa5deeb6a659f26278ced75775ec00ebc888a95a814b201f306ff7d84d5L262-R262) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL75-R76) [[3]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL77-R78) [[4]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbR89-R93) [[5]](diffhunk://#diff-82ab8c35ebc5e8b32719c6b0a0c09de92b9cde7e6e486b9a61300e618f1102dfL49-R49)

* Added `numba` and `setuptools` as runtime dependencies, and clarified which packages are required for core functionality versus examples and development. [[1]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL75-R76) [[2]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL77-R78) [[3]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbR89-R93)

**Versioning and Miscellaneous:**

* Bumped version number to 3.9.8 in all relevant files, and made minor documentation and test fixture updates. [[1]](diffhunk://#diff-c157bf6a4fcea5e19ccb39979beb75b999c94a5e950492d7e423760fd4320208L2-R2) [[2]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L24-R24) [[3]](diffhunk://#diff-ebf62456207d5dcd8d8e551d58b092ff58aa2b59f233fad9dc6e152584f77db8L7-R7) [[4]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L33-R33) [[5]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R46)