### PR TITLE
feat(adaptive): add optional round_output parameter to adaptive_ashrae and adaptive_en

### DIFF
--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -213,6 +213,7 @@ class ASHRAEInputs(BaseInputs):
         t_running_mean,
         v,
         units,
+        round_output=True,
     ):
         super().__init__(
             tdb=tdb,
@@ -220,6 +221,7 @@ class ASHRAEInputs(BaseInputs):
             v=v,
             units=units,
             t_running_mean=t_running_mean,
+            round_output=round_output,
         )
 
 
@@ -232,6 +234,7 @@ class ENInputs(BaseInputs):
         t_running_mean,
         v,
         units,
+        round_output=True,
     ):
         super().__init__(
             tdb=tdb,
@@ -239,6 +242,7 @@ class ENInputs(BaseInputs):
             v=v,
             units=units,
             t_running_mean=t_running_mean,
+            round_output=round_output,
         )
 
 

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -21,6 +21,7 @@ def adaptive_ashrae(
     v: float | list[float],
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
+    round_output: bool = True,
 ) -> AdaptiveASHRAE:
     """Calculate the adaptive thermal comfort based on ASHRAE 55.
 
@@ -56,6 +57,14 @@ def adaptive_ashrae(
 
         .. note::
             ASHRAE 55 2020 limits: 10 < tdb [°C] < 40, 10 < tr [°C] < 40, 0 < vr [m/s] < 2, 10 < t_running_mean [°C] < 33.5.
+
+    round_output : bool, optional
+        If True, rounds ``t_cmf`` to one decimal place in SI before the comfort bounds are
+        derived, so ``tmp_cmf_80_low``, ``tmp_cmf_80_up``, ``tmp_cmf_90_low`` and
+        ``tmp_cmf_90_up`` inherit that rounding. If False, ``t_cmf`` and the derived bounds
+        are returned at full precision. Under ``units='IP'`` the rounded SI value is then
+        converted to °F, so IP outputs carry the extra decimals from the °C-to-°F conversion.
+        Defaults to True.
 
     Returns
     -------
@@ -97,6 +106,7 @@ def adaptive_ashrae(
         t_running_mean=t_running_mean,
         v=v,
         units=units,
+        round_output=round_output,
     )
 
     tdb = np.asarray(tdb)
@@ -141,7 +151,8 @@ def adaptive_ashrae(
         )
         t_cmf = np.where(all_valid, t_cmf, np.nan)
 
-    t_cmf = np.around(t_cmf, 1)
+    if round_output:
+        t_cmf = np.around(t_cmf, 1)
 
     tmp_cmf_80_low = t_cmf - 3.5
     tmp_cmf_90_low = t_cmf - 2.5

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -15,6 +15,7 @@ def adaptive_en(
     v: float | list[float],
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
+    round_output: bool = True,
 ) -> AdaptiveEN:
     """Calculate the adaptive thermal comfort based on EN 16798-1 2019 [16798EN2019]_.
 
@@ -45,6 +46,11 @@ def adaptive_en(
         Select the SI (International System of Units) or the IP (Imperial Units) system.
     limit_inputs : bool, default True
         If True, returns NaN for inputs outside the standard applicability limits.
+
+    round_output : bool, default True
+        If True, rounds the returned comfort temperature and category bounds to one decimal
+        place in the output unit (rounding is applied after any IP unit conversion).
+        If False, returns the unrounded values.
 
     Returns
     -------
@@ -78,7 +84,14 @@ def adaptive_en(
         # if the running mean temperature is between 10 °C and 30 °C.
     """
     # Validate inputs using the ENInputs class
-    ENInputs(tdb=tdb, tr=tr, t_running_mean=t_running_mean, v=v, units=units)
+    ENInputs(
+        tdb=tdb,
+        tr=tr,
+        t_running_mean=t_running_mean,
+        v=v,
+        units=units,
+        round_output=round_output,
+    )
 
     tdb = np.asarray(tdb)
     tr = np.asarray(tr)
@@ -136,15 +149,24 @@ def adaptive_en(
             tmp_cmf_cat_iii_low=t_cmf_iii_lower,
         )
 
+    if round_output:
+        t_cmf = np.around(t_cmf, 1)
+        t_cmf_i_lower = np.around(t_cmf_i_lower, 1)
+        t_cmf_ii_lower = np.around(t_cmf_ii_lower, 1)
+        t_cmf_iii_lower = np.around(t_cmf_iii_lower, 1)
+        t_cmf_i_upper = np.around(t_cmf_i_upper, 1)
+        t_cmf_ii_upper = np.around(t_cmf_ii_upper, 1)
+        t_cmf_iii_upper = np.around(t_cmf_iii_upper, 1)
+
     return AdaptiveEN(
-        tmp_cmf=np.around(t_cmf, 1),
+        tmp_cmf=t_cmf,
         acceptability_cat_i=acceptability_i,
         acceptability_cat_ii=acceptability_ii,
         acceptability_cat_iii=acceptability_iii,
-        tmp_cmf_cat_i_up=np.around(t_cmf_i_upper, 1),
-        tmp_cmf_cat_ii_up=np.around(t_cmf_ii_upper, 1),
-        tmp_cmf_cat_iii_up=np.around(t_cmf_iii_upper, 1),
-        tmp_cmf_cat_i_low=np.around(t_cmf_i_lower, 1),
-        tmp_cmf_cat_ii_low=np.around(t_cmf_ii_lower, 1),
-        tmp_cmf_cat_iii_low=np.around(t_cmf_iii_lower, 1),
+        tmp_cmf_cat_i_up=t_cmf_i_upper,
+        tmp_cmf_cat_ii_up=t_cmf_ii_upper,
+        tmp_cmf_cat_iii_up=t_cmf_iii_upper,
+        tmp_cmf_cat_i_low=t_cmf_i_lower,
+        tmp_cmf_cat_ii_low=t_cmf_ii_lower,
+        tmp_cmf_cat_iii_low=t_cmf_iii_lower,
     )

--- a/tests/test_adaptive_ashrae.py
+++ b/tests/test_adaptive_ashrae.py
@@ -79,3 +79,73 @@ def test_nan_values_for_invalid_inputs() -> None:
     # Check that the acceptability flags are False
     assert result.acceptability_80 == False
     assert result.acceptability_90 == False
+
+
+def test_round_output_default_preserves_behaviour() -> None:
+    """Default call must match an explicit round_output=True call."""
+    default_result = adaptive_ashrae(tdb=25, tr=25, t_running_mean=21.5, v=0.1)
+    explicit_result = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert default_result.tmp_cmf == explicit_result.tmp_cmf
+    assert default_result.tmp_cmf_80_low == explicit_result.tmp_cmf_80_low
+    assert default_result.tmp_cmf_80_up == explicit_result.tmp_cmf_80_up
+    assert default_result.tmp_cmf_90_low == explicit_result.tmp_cmf_90_low
+    assert default_result.tmp_cmf_90_up == explicit_result.tmp_cmf_90_up
+
+
+def test_round_output_false_returns_unrounded() -> None:
+    """round_output=False must return unrounded t_cmf at full precision."""
+    # 0.31 * 21.5 + 17.8 = 24.465; rounded to 1 dp this is 24.5.
+    unrounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=False,
+    )
+    rounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert np.isclose(unrounded.tmp_cmf, 24.465)
+    assert np.isclose(rounded.tmp_cmf, 24.5)
+    assert unrounded.tmp_cmf != rounded.tmp_cmf
+
+
+def test_round_output_false_propagates_to_bounds() -> None:
+    """Unrounded t_cmf must propagate into the derived comfort bounds."""
+    unrounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=False,
+    )
+
+    # tmp_cmf_80_low = t_cmf - 3.5; with unrounded t_cmf=24.465 this is 20.965.
+    assert np.isclose(unrounded.tmp_cmf_80_low, 24.465 - 3.5)
+    assert np.isclose(unrounded.tmp_cmf_90_low, 24.465 - 2.5)
+    assert np.isclose(unrounded.tmp_cmf_80_up, 24.465 + 3.5)
+    assert np.isclose(unrounded.tmp_cmf_90_up, 24.465 + 2.5)
+
+
+def test_round_output_invalid_type_raises() -> None:
+    """A non-boolean round_output must raise TypeError."""
+    with pytest.raises(TypeError):
+        adaptive_ashrae(
+            tdb=25,
+            tr=25,
+            t_running_mean=20,
+            v=0.1,
+            round_output="yes",
+        )

--- a/tests/test_adaptive_en.py
+++ b/tests/test_adaptive_en.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pythermalcomfort.models import adaptive_en
@@ -54,3 +55,54 @@ def test_ashrae_inputs_invalid_v_type() -> None:
     """Test that the function raises a TypeError for invalid v type."""
     with pytest.raises(TypeError):
         adaptive_en(tdb=25, tr=25, t_running_mean=20, v="invalid")
+
+
+def test_round_output_default_preserves_behaviour() -> None:
+    """Default call must match an explicit round_output=True call."""
+    default_result = adaptive_en(tdb=25, tr=25, t_running_mean=20.5, v=0.1)
+    explicit_result = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert default_result.tmp_cmf == explicit_result.tmp_cmf
+    assert default_result.tmp_cmf_cat_i_up == explicit_result.tmp_cmf_cat_i_up
+    assert default_result.tmp_cmf_cat_i_low == explicit_result.tmp_cmf_cat_i_low
+    assert default_result.tmp_cmf_cat_ii_up == explicit_result.tmp_cmf_cat_ii_up
+    assert default_result.tmp_cmf_cat_iii_low == explicit_result.tmp_cmf_cat_iii_low
+
+
+def test_round_output_false_returns_unrounded() -> None:
+    """round_output=False must return unrounded t_cmf and bounds at full precision."""
+    # 0.33 * 20.5 + 18.8 = 25.565; rounded to 1 dp this is 25.6.
+    unrounded = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=False,
+    )
+    rounded = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert np.isclose(unrounded.tmp_cmf, 25.565)
+    assert np.isclose(rounded.tmp_cmf, 25.6)
+    assert unrounded.tmp_cmf != rounded.tmp_cmf
+
+    # Bounds derive from the unrounded value when round_output=False.
+    assert np.isclose(unrounded.tmp_cmf_cat_i_low, 25.565 - 3.0)
+    assert np.isclose(unrounded.tmp_cmf_cat_ii_up, 25.565 + 3.0)
+
+
+def test_round_output_invalid_type_raises() -> None:
+    """A non-boolean round_output must raise TypeError."""
+    with pytest.raises(TypeError):
+        adaptive_en(tdb=25, tr=25, t_running_mean=20, v=0.1, round_output="yes")


### PR DESCRIPTION
Closes #323.

Adds an optional round_output parameter (default True) to adaptive_ashrae and adaptive_en. Default behaviour is unchanged. With round_output=False, comfort temperatures and category bounds are returned at full precision.

For adaptive_ashrae, t_cmf is rounded before the comfort bounds (tmp_cmf_80_low, tmp_cmf_80_up, tmp_cmf_90_low, tmp_cmf_90_up) are derived in the current implementation, so the unrounded path also propagates into bound derivation. This matches the behaviour shipped in FedericoTartarini/jsthermalcomfort#176.

For adaptive_en, the seven returned values are each rounded at the return site, so under round_output=False they are all returned at full precision.

The parameter is threaded through ASHRAEInputs and ENInputs so the existing is_bool validation raises TypeError for non-boolean values.

New tests cover default behaviour preservation, unrounded values under round_output=False, the ASHRAE-specific bound-derivation propagation, and the non-boolean type check.