### PR TITLE
Add UserWarning for out-of-range inputs and enhance compliance checks

### DIFF
--- a/.github/workflows/build-test-publish-testPyPI.yml
+++ b/.github/workflows/build-test-publish-testPyPI.yml
@@ -11,28 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  format:
-    if: github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools
-          python -m pip install ruff
-      - name: Lint
-        run: ruff check ./pythermalcomfort ./tests
-      - name: Check formatting
-        run: ruff format --check ./pythermalcomfort ./tests
-
   test:
-    if: github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/')
-    needs: format
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,11 +19,11 @@ jobs:
         platform: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Tox and any other packages
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools
@@ -60,7 +39,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
   deploy-testpypi:
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, 'rc')
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'rc')
     needs: test
     runs-on: ubuntu-latest
     permissions:
@@ -84,7 +63,7 @@ jobs:
           python -m pip install build
       - name: Build distribution packages
         run: python -m build
-      - name: Publish pythermalcomfort to TestPyPI
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -51,16 +51,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6.0.2
-      with:
-        fetch-depth: 0
     - name: Set up Python 🐍
       uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.11'
-    - name: Ensure tag commit is on master
-      run: |
-        git fetch origin master
-        git merge-base --is-ancestor "$GITHUB_SHA" "origin/master"
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     branches:
         - development
+        - master
 
 jobs:
 
@@ -49,11 +50,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install setuptools
           python -m pip install "tox<4" tox-gh-actions
-          python -m pip install ruff
-      - name: Lint
-        run: ruff check ./pythermalcomfort ./tests
-      - name: Check formatting
-        run: ruff format --check ./pythermalcomfort ./tests
       - name: Run Tox
         run: |
           tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+3.9.8 (2026-05-25)
+------------------
+
+* Added optional ``round_output`` parameter to ``adaptive_ashrae`` and ``adaptive_en``
+  to control rounding of output values.
+* Added ``limit_inputs`` parameter to ``ankle_draft`` and ``vertical_tmp_grad_ppd``,
+  consistent with other model functions.
+* ``ankle_draft`` and ``vertical_tmp_grad_ppd`` now raise ``UserWarning`` when inputs
+  exceed model applicability limits.
+* Fixed ``compliance`` attribute being included in non-ASHRAE PMV model outputs;
+  it is now only returned by ``pmv_ppd_ashrae``.
+* Fixed UTCI stress category mapping when ``units="IP"``; categories were
+  incorrectly mapped before IP unit conversion.
+
+3.9.3 (2026-05-01)
+------------------
+
+* Maintenance release: internal CI pipeline improvements and dependency updates.
+  No user-facing changes.
+
 3.9.2 (2026-04-14)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -166,30 +166,17 @@ Common commands
 Release process
 ---------------
 
-Releases are tag-driven and published via GitHub Actions Trusted Publishing.
+Releases are tag-driven and published via GitHub Actions Trusted Publishing
+(OIDC — no ``PYPI_API_TOKEN`` or ``TEST_PYPI_API_TOKEN`` secret is required).
 
-Production release (PyPI)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+The standard cycle is:
 
-.. code-block:: bash
+1. Develop and test a release candidate on ``development`` → TestPyPI.
+2. Merge ``development`` → ``master`` via pull request.
+3. Finalize the version on ``master`` → PyPI.
 
-    # prepare local release branch
-    git checkout master
-    git pull --ff-only
-    git fetch --tags --prune
-
-    # finalize an rc to stable release
-    bump-my-version bump patch     # or minor / major for a fresh release
-
-    # publish commit and tag (tag push triggers PyPI release workflow)
-    git push
-    git push --tags
-
-Pre-release (TestPyPI)
-~~~~~~~~~~~~~~~~~~~~~~
-
-Use pre-release tags from ``development`` to validate packaging before releasing
-to PyPI.
+Step 1 — pre-release on ``development`` (TestPyPI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -197,30 +184,50 @@ to PyPI.
     git pull --ff-only
     git fetch --tags --prune
 
-    # start rc cycle for next patch (creates e.g. 3.9.6rc1)
+    # Start the RC cycle for the next patch release (e.g. 3.9.8 → 3.9.9rc1):
     bump-my-version bump patch
 
-    # iterate rc builds while testing (rc1 -> rc2 -> rc3 ...)
-    bump-my-version bump pre_n
-
-    # publish commit and tag (tag push triggers TestPyPI release workflow)
+    # Push the bump commit and tag — this triggers tests + TestPyPI deploy:
     git push
     git push --tags
 
-If additional commits are made after an ``rc`` tag, create a new pre-release
-tag by running ``bump-my-version bump pre_n`` again, then push commit and tags.
+If the RC needs additional fixes, make the commits then create another RC:
 
-Rules and safeguards:
+.. code-block:: bash
 
-* Keep ``.bumpversion.toml`` and git tags aligned.
-* Tag format is standardized as ``vX.Y.Z`` and ``vX.Y.ZrcN``.
-* Production tags must point to commits reachable from ``master``.
-* TestPyPI publishing is triggered by tags matching ``v*rc*`` and those tags
-  must point to commits reachable from ``development``.
-* If a version exists in files but not as a tag, create and push the missing tag
-  before the next bump.
-* PyPI and TestPyPI publishing both use Trusted Publisher (OIDC), so no
-  ``PYPI_API_TOKEN`` or ``TEST_PYPI_API_TOKEN`` secret is required.
+    bump-my-version bump pre_n    # e.g. 3.9.9rc1 → 3.9.9rc2
+    git push
+    git push --tags
+
+Step 2 — open and merge a pull request from ``development`` to ``master``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CI runs the full test suite on the PR. Once it passes, merge via GitHub.
+
+Step 3 — finalize on ``master`` (PyPI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    git checkout master
+    git pull --ff-only
+    git fetch --tags --prune
+
+    # Strip the rc suffix to produce the stable version.
+    # Replace X.Y.Z with the target version (e.g. 3.9.9):
+    bump-my-version bump --new-version X.Y.Z patch
+
+    # Push the bump commit and tag — this triggers tests + PyPI deploy:
+    git push
+    git push --tags
+
+Rules:
+
+* All RC tags (``vX.Y.ZrcN``) must be pushed from ``development``.
+* All stable tags (``vX.Y.Z``) must be pushed from ``master`` after merging.
+* Tag format: ``vX.Y.Z`` for stable, ``vX.Y.ZrcN`` for pre-release.
+* Do not push a stable tag before the corresponding ``development`` → ``master``
+  PR has been merged; the CI deploy job will reject it.
 
 Getting Help
 ============

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -254,6 +254,7 @@ class AnkleDraftInputs(BaseInputs):
         clo,
         v_ankle,
         units=Units.SI.value,
+        limit_inputs=True,
     ):
         # Initialize with only required fields, setting others to None
         super().__init__(
@@ -265,6 +266,7 @@ class AnkleDraftInputs(BaseInputs):
             clo=clo,
             v_ankle=v_ankle,
             units=units,
+            limit_inputs=limit_inputs,
         )
 
 
@@ -967,6 +969,7 @@ class VerticalTGradPPDInputs(BaseInputs):
         clo,
         vertical_tmp_grad,
         units=Units.SI.value,
+        limit_inputs=True,
     ):
         # Initialize with only required fields, setting others to None
         super().__init__(
@@ -978,6 +981,7 @@ class VerticalTGradPPDInputs(BaseInputs):
             clo=clo,
             vertical_tmp_grad=vertical_tmp_grad,
             units=units,
+            limit_inputs=limit_inputs,
         )
 
 

--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -213,6 +213,7 @@ class ASHRAEInputs(BaseInputs):
         t_running_mean,
         v,
         units,
+        round_output=True,
     ):
         super().__init__(
             tdb=tdb,
@@ -220,6 +221,7 @@ class ASHRAEInputs(BaseInputs):
             v=v,
             units=units,
             t_running_mean=t_running_mean,
+            round_output=round_output,
         )
 
 
@@ -232,6 +234,7 @@ class ENInputs(BaseInputs):
         t_running_mean,
         v,
         units,
+        round_output=True,
     ):
         super().__init__(
             tdb=tdb,
@@ -239,6 +242,7 @@ class ENInputs(BaseInputs):
             v=v,
             units=units,
             t_running_mean=t_running_mean,
+            round_output=round_output,
         )
 
 

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -21,6 +21,7 @@ def adaptive_ashrae(
     v: float | list[float],
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
+    round_output: bool = True,
 ) -> AdaptiveASHRAE:
     """Calculate the adaptive thermal comfort based on ASHRAE 55.
 
@@ -56,6 +57,14 @@ def adaptive_ashrae(
 
         .. note::
             ASHRAE 55 2020 limits: 10 < tdb [°C] < 40, 10 < tr [°C] < 40, 0 < vr [m/s] < 2, 10 < t_running_mean [°C] < 33.5.
+
+    round_output : bool, optional
+        If True, rounds ``t_cmf`` to one decimal place in SI before the comfort bounds are
+        derived, so ``tmp_cmf_80_low``, ``tmp_cmf_80_up``, ``tmp_cmf_90_low`` and
+        ``tmp_cmf_90_up`` inherit that rounding. If False, ``t_cmf`` and the derived bounds
+        are returned at full precision. Under ``units='IP'`` the rounded SI value is then
+        converted to °F, so IP outputs carry the extra decimals from the °C-to-°F conversion.
+        Defaults to True.
 
     Returns
     -------
@@ -97,6 +106,7 @@ def adaptive_ashrae(
         t_running_mean=t_running_mean,
         v=v,
         units=units,
+        round_output=round_output,
     )
 
     tdb = np.asarray(tdb)
@@ -141,7 +151,8 @@ def adaptive_ashrae(
         )
         t_cmf = np.where(all_valid, t_cmf, np.nan)
 
-    t_cmf = np.around(t_cmf, 1)
+    if round_output:
+        t_cmf = np.around(t_cmf, 1)
 
     tmp_cmf_80_low = t_cmf - 3.5
     tmp_cmf_90_low = t_cmf - 2.5

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -113,14 +113,6 @@ def adaptive_ashrae(
             v=v,
         )
 
-    tdb_valid, tr_valid, v_valid = _check_standard_compliance_array(
-        Models.ashrae_55_2023.value,
-        tdb=tdb,
-        tr=tr,
-        v=v,
-    )
-    trm_valid = valid_range(t_running_mean, (10.0, 33.5))
-
     to = operative_tmp(tdb, tr, v, standard=standard)
 
     # Calculate cooling effect (ce) of elevated air speed when top > 25 degC.
@@ -133,6 +125,13 @@ def adaptive_ashrae(
     t_cmf = 0.31 * t_running_mean + 17.8
 
     if limit_inputs:
+        tdb_valid, tr_valid, v_valid = _check_standard_compliance_array(
+            Models.ashrae_55_2023.value,
+            tdb=tdb,
+            tr=tr,
+            v=v,
+        )
+        trm_valid = valid_range(t_running_mean, (10.0, 33.5), "t_running_mean")
         all_valid = ~(
             np.isnan(tdb_valid)
             | np.isnan(tr_valid)

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -6,9 +6,8 @@ from pythermalcomfort.classes_input import ASHRAEInputs
 from pythermalcomfort.classes_return import AdaptiveASHRAE
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
-    Models,
     Units,
-    _check_standard_compliance_array,
+    _check_ashrae55_compliance,
     operative_tmp,
     units_converter,
 )
@@ -125,13 +124,12 @@ def adaptive_ashrae(
     t_cmf = 0.31 * t_running_mean + 17.8
 
     if limit_inputs:
-        tdb_valid, tr_valid, v_valid = _check_standard_compliance_array(
-            Models.ashrae_55_2023.value,
+        tdb_valid, tr_valid, v_valid = _check_ashrae55_compliance(
             tdb=tdb,
             tr=tr,
             v=v,
         )
-        trm_valid = valid_range(t_running_mean, (10.0, 33.5), "t_running_mean")
+        trm_valid = valid_range(t_running_mean, (10.0, 33.5))
         all_valid = ~(
             np.isnan(tdb_valid)
             | np.isnan(tr_valid)

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -105,7 +105,7 @@ def adaptive_en(
     t_cmf = 0.33 * t_running_mean + 18.8
 
     if limit_inputs:
-        trm_valid = valid_range(t_running_mean, (10.0, 33.5), "t_running_mean")
+        trm_valid = valid_range(t_running_mean, (10.0, 33.5))
         all_valid = ~(np.isnan(trm_valid))
         t_cmf = np.where(all_valid, t_cmf, np.nan)
 

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -15,6 +15,7 @@ def adaptive_en(
     v: float | list[float],
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
+    round_output: bool = True,
 ) -> AdaptiveEN:
     """Calculate the adaptive thermal comfort based on EN 16798-1 2019 [16798EN2019]_.
 
@@ -45,6 +46,11 @@ def adaptive_en(
         Select the SI (International System of Units) or the IP (Imperial Units) system.
     limit_inputs : bool, default True
         If True, returns NaN for inputs outside the standard applicability limits.
+
+    round_output : bool, default True
+        If True, rounds the returned comfort temperature and category bounds to one decimal
+        place in the output unit (rounding is applied after any IP unit conversion).
+        If False, returns the unrounded values.
 
     Returns
     -------
@@ -78,7 +84,14 @@ def adaptive_en(
         # if the running mean temperature is between 10 °C and 30 °C.
     """
     # Validate inputs using the ENInputs class
-    ENInputs(tdb=tdb, tr=tr, t_running_mean=t_running_mean, v=v, units=units)
+    ENInputs(
+        tdb=tdb,
+        tr=tr,
+        t_running_mean=t_running_mean,
+        v=v,
+        units=units,
+        round_output=round_output,
+    )
 
     tdb = np.asarray(tdb)
     tr = np.asarray(tr)
@@ -136,15 +149,24 @@ def adaptive_en(
             tmp_cmf_cat_iii_low=t_cmf_iii_lower,
         )
 
+    if round_output:
+        t_cmf = np.around(t_cmf, 1)
+        t_cmf_i_lower = np.around(t_cmf_i_lower, 1)
+        t_cmf_ii_lower = np.around(t_cmf_ii_lower, 1)
+        t_cmf_iii_lower = np.around(t_cmf_iii_lower, 1)
+        t_cmf_i_upper = np.around(t_cmf_i_upper, 1)
+        t_cmf_ii_upper = np.around(t_cmf_ii_upper, 1)
+        t_cmf_iii_upper = np.around(t_cmf_iii_upper, 1)
+
     return AdaptiveEN(
-        tmp_cmf=np.around(t_cmf, 1),
+        tmp_cmf=t_cmf,
         acceptability_cat_i=acceptability_i,
         acceptability_cat_ii=acceptability_ii,
         acceptability_cat_iii=acceptability_iii,
-        tmp_cmf_cat_i_up=np.around(t_cmf_i_upper, 1),
-        tmp_cmf_cat_ii_up=np.around(t_cmf_ii_upper, 1),
-        tmp_cmf_cat_iii_up=np.around(t_cmf_iii_upper, 1),
-        tmp_cmf_cat_i_low=np.around(t_cmf_i_lower, 1),
-        tmp_cmf_cat_ii_low=np.around(t_cmf_ii_lower, 1),
-        tmp_cmf_cat_iii_low=np.around(t_cmf_iii_lower, 1),
+        tmp_cmf_cat_i_up=t_cmf_i_upper,
+        tmp_cmf_cat_ii_up=t_cmf_ii_upper,
+        tmp_cmf_cat_iii_up=t_cmf_iii_upper,
+        tmp_cmf_cat_i_low=t_cmf_i_lower,
+        tmp_cmf_cat_ii_low=t_cmf_ii_lower,
+        tmp_cmf_cat_iii_low=t_cmf_iii_lower,
     )

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -94,8 +94,6 @@ def adaptive_en(
             v=v,
         )
 
-    trm_valid = valid_range(t_running_mean, (10.0, 33.5))
-
     to = operative_tmp(tdb, tr, v, standard=standard)
 
     # Calculate cooling effect (ce) of elevated air speed when top > 25 degC.
@@ -107,6 +105,7 @@ def adaptive_en(
     t_cmf = 0.33 * t_running_mean + 18.8
 
     if limit_inputs:
+        trm_valid = valid_range(t_running_mean, (10.0, 33.5), "t_running_mean")
         all_valid = ~(np.isnan(trm_valid))
         t_cmf = np.where(all_valid, t_cmf, np.nan)
 

--- a/pythermalcomfort/models/ankle_draft.py
+++ b/pythermalcomfort/models/ankle_draft.py
@@ -111,12 +111,16 @@ def ankle_draft(
     if units.upper() == Units.IP.value:
         tdb, tr, vr, v_ankle = units_converter(tdb=tdb, tr=tr, vr=vr, vel=v_ankle)
 
-    tdb_valid, tr_valid, v_valid, v_limited = _check_standard_compliance_array(
-        standard=Models.ashrae_55_2023.value,
-        tdb=tdb,
-        tr=tr,
-        v_limited=vr,
-        v=vr,
+    tdb_valid, tr_valid, v_valid, met_valid, clo_valid, v_limited = (
+        _check_standard_compliance_array(
+            standard=Models.ashrae_55_2023.value,
+            tdb=tdb,
+            tr=tr,
+            v_limited=vr,
+            v=vr,
+            met=met,
+            clo=clo,
+        )
     )
 
     if np.all(np.isnan(v_limited)):
@@ -132,6 +136,7 @@ def ankle_draft(
         met,
         clo,
         model=Models.ashrae_55_2023.value,
+        limit_inputs=False,
     ).pmv
     ppd_val = np.around(
         np.exp(-2.58 + 3.05 * v_ankle - 1.06 * tsv)
@@ -140,4 +145,15 @@ def ankle_draft(
         1,
     )
     acceptability = ppd_val <= 20
+
+    all_valid = ~(
+        np.isnan(tdb_valid)
+        | np.isnan(tr_valid)
+        | np.isnan(v_valid)
+        | np.isnan(met_valid)
+        | np.isnan(clo_valid)
+    )
+    ppd_val = np.where(all_valid, ppd_val, np.nan)
+    acceptability = np.where(all_valid, acceptability, np.nan)
+
     return AnkleDraft(ppd_ad=ppd_val, acceptability=acceptability)

--- a/pythermalcomfort/models/ankle_draft.py
+++ b/pythermalcomfort/models/ankle_draft.py
@@ -22,6 +22,7 @@ def ankle_draft(
     clo: float | list[float],
     v_ankle: float | list[float],
     units: str = Units.SI.value,
+    limit_inputs: bool = True,
 ) -> AnkleDraft:
     """Calculate the percentage of thermally dissatisfied people with the ankle draft
     (0.1 m) above floor level [Liu2017]_.
@@ -71,6 +72,12 @@ def ankle_draft(
 
     units : {'SI', 'IP'}
         Select the SI (International System of Units) or the IP (Imperial Units) system.
+    limit_inputs : bool, optional
+        By default, if the inputs are outside the standard applicability limits the
+        function returns nan. If False, returns values even if input values are
+        outside the applicability limits of the model. Defaults to True. The
+        applicability limits are 10 < tdb [°C] < 40, 10 < tr [°C] < 40,
+        0 < vr [m/s] < 0.2, 1 < met [met] < 4, and 0 < clo [clo] < 1.5.
 
     Returns
     -------
@@ -97,6 +104,7 @@ def ankle_draft(
         clo=clo,
         v_ankle=v_ankle,
         units=units,
+        limit_inputs=limit_inputs,
     )
 
     # Convert lists to numpy arrays
@@ -110,23 +118,6 @@ def ankle_draft(
 
     if units.upper() == Units.IP.value:
         tdb, tr, vr, v_ankle = units_converter(tdb=tdb, tr=tr, vr=vr, vel=v_ankle)
-
-    tdb_valid, tr_valid, v_valid, met_valid, clo_valid, v_limited = (
-        _check_ashrae55_compliance(
-            tdb=tdb,
-            tr=tr,
-            v_limited=vr,
-            v=vr,
-            met=met,
-            clo=clo,
-            v_param_name="vr",
-        )
-    )
-
-    if np.all(np.isnan(v_limited)):
-        raise ValueError(
-            "This equation is only applicable for air speed lower than 0.2 m/s",
-        )
 
     tsv = pmv_ppd_ashrae(
         tdb,
@@ -146,14 +137,32 @@ def ankle_draft(
     )
     acceptability = ppd_val <= 20
 
-    all_valid = ~(
-        np.isnan(tdb_valid)
-        | np.isnan(tr_valid)
-        | np.isnan(v_valid)
-        | np.isnan(met_valid)
-        | np.isnan(clo_valid)
-    )
-    ppd_val = np.where(all_valid, ppd_val, np.nan)
-    acceptability = np.where(all_valid, acceptability, np.nan)
+    if limit_inputs:
+        tdb_valid, tr_valid, v_valid, met_valid, clo_valid, v_limited = (
+            _check_ashrae55_compliance(
+                tdb=tdb,
+                tr=tr,
+                v_limited=vr,
+                v=vr,
+                met=met,
+                clo=clo,
+                v_param_name="vr",
+            )
+        )
+
+        if np.all(np.isnan(v_limited)):
+            raise ValueError(
+                "This equation is only applicable for air speed lower than 0.2 m/s",
+            )
+
+        all_valid = ~(
+            np.isnan(tdb_valid)
+            | np.isnan(tr_valid)
+            | np.isnan(v_valid)
+            | np.isnan(met_valid)
+            | np.isnan(clo_valid)
+        )
+        ppd_val = np.where(all_valid, ppd_val, np.nan)
+        acceptability = np.where(all_valid, acceptability, np.nan)
 
     return AnkleDraft(ppd_ad=ppd_val, acceptability=acceptability)

--- a/pythermalcomfort/models/ankle_draft.py
+++ b/pythermalcomfort/models/ankle_draft.py
@@ -8,7 +8,7 @@ from pythermalcomfort.models.pmv_ppd_ashrae import pmv_ppd_ashrae
 from pythermalcomfort.utilities import (
     Models,
     Units,
-    _check_standard_compliance_array,
+    _check_ashrae55_compliance,
     units_converter,
 )
 
@@ -112,14 +112,14 @@ def ankle_draft(
         tdb, tr, vr, v_ankle = units_converter(tdb=tdb, tr=tr, vr=vr, vel=v_ankle)
 
     tdb_valid, tr_valid, v_valid, met_valid, clo_valid, v_limited = (
-        _check_standard_compliance_array(
-            standard=Models.ashrae_55_2023.value,
+        _check_ashrae55_compliance(
             tdb=tdb,
             tr=tr,
             v_limited=vr,
             v=vr,
             met=met,
             clo=clo,
+            v_param_name="vr",
         )
     )
 

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from pythermalcomfort.classes_input import HIInputs
 from pythermalcomfort.classes_return import HI
-from pythermalcomfort.shared_functions import mapping
+from pythermalcomfort.shared_functions import mapping, valid_range
 
 
 def heat_index_rothfusz(
@@ -24,6 +24,15 @@ def heat_index_rothfusz(
         Relative humidity, [%].
     round_output : bool, optional
         If True, rounds output value. If False, it does not round it. Defaults to True.
+    limit_inputs : bool, optional
+        If True, limits the inputs to the standard applicability limits. Defaults to True.
+
+        .. note::
+            By default, if the inputs are outside the standard applicability limits the
+            function returns NaN. If False returns heat index
+            values even if input values are outside the applicability limits of the model.
+
+            The applicability limit is tdb >= 27°C.
 
     Returns
     -------
@@ -59,9 +68,8 @@ def heat_index_rothfusz(
 
     # heat index should only be calculated for temperatures above 27 °C
     if limit_inputs:
-        tdb_valid = np.where((tdb >= 27.0), tdb, np.nan)
-        all_valid = ~(np.isnan(tdb_valid))
-        hi_valid = np.where(all_valid, hi, np.nan)
+        tdb_valid = valid_range(tdb, (27.0, np.inf), "tdb")
+        hi_valid = np.where(~np.isnan(tdb_valid), hi, np.nan)
     else:
         hi_valid = hi
 

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -68,7 +68,7 @@ def heat_index_rothfusz(
 
     # heat index should only be calculated for temperatures above 27 °C
     if limit_inputs:
-        tdb_valid = valid_range(tdb, (27.0, np.inf), "tdb")
+        tdb_valid = valid_range(tdb, (27.0, np.inf))
         hi_valid = np.where(~np.isnan(tdb_valid), hi, np.nan)
     else:
         hi_valid = hi

--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -7,10 +7,10 @@ from numba import jit, prange
 
 from pythermalcomfort.classes_input import PHSInputs
 from pythermalcomfort.classes_return import PHS
+from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
     Models,
     Postures,
-    _check_standard_compliance_array,
     met_to_w_m2,
     p_sat,
 )
@@ -423,22 +423,15 @@ def phs(
     }
 
     if limit_inputs:
-        (
-            tdb_valid,
-            tr_valid,
-            v_valid,
-            p_a_valid,
-            met_valid,
-            clo_valid,
-        ) = _check_standard_compliance_array(
-            model,
-            tdb=tdb,
-            tr=tr,
-            v=v,
-            met=met,
-            clo=clo,
-            p_a=p_a,
-        )
+        # ISO 7933 Annex A applicability limits. p_a lower bound is 0.5 in the
+        # 2023 revision and 0 in the 2004 edition; all other limits are identical.
+        p_a_lower = 0.5 if model == Models.iso_7933_2023.value else 0
+        tdb_valid = valid_range(tdb, (15.0, 50.0))
+        tr_valid = valid_range(tr, (0.0, 60.0))
+        v_valid = valid_range(v, (0.0, 3.0))
+        p_a_valid = valid_range(p_a, (p_a_lower, 4.5))
+        met_valid = valid_range(met, (100, 450))
+        clo_valid = valid_range(clo, (0.1, 1.0))
         all_valid = ~(
             np.isnan(tdb_valid)
             | np.isnan(tr_valid)

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -173,8 +173,28 @@ def pmv_ppd_ashrae(
         )
         raise ValueError(error_msg)
 
-    # Checks that inputs are within the bounds accepted by the model if not return nan
-    # Must be done before CE correction to use the original input values
+    # if v_r is higher than 0.1 follow methodology ASHRAE Appendix H, H3
+    ce = np.where(
+        vr > 0.1,
+        cooling_effect(tdb=tdb, tr=tr, vr=vr, rh=rh, met=met, clo=clo, wme=wme).ce,
+        0.0,
+    )
+
+    tdb_ce = tdb - ce
+    tr_ce = tr - ce
+    vr_ce = np.where(ce > 0, 0.1, vr)
+
+    pmv_array = _pmv_ppd_optimized(tdb_ce, tr_ce, vr_ce, rh, met, clo, wme)
+
+    ppd_array = 100.0 - 95.0 * np.exp(
+        -0.03353 * pmv_array**4.0 - 0.2179 * pmv_array**2.0,
+    )
+
+    # Calculate compliance: True if -0.5 < PMV < 0.5
+    compliance_array = (pmv_array > -0.5) & (pmv_array < 0.5)
+    # Ensure object dtype for compliance array
+    compliance_array = np.asarray(compliance_array, dtype=object)
+
     if limit_inputs:
         (
             tdb_valid,
@@ -191,30 +211,6 @@ def pmv_ppd_ashrae(
             clo=clo,
             airspeed_control=airspeed_control,
         )
-
-    # if v_r is higher than 0.1 follow methodology ASHRAE Appendix H, H3
-    ce = np.where(
-        vr > 0.1,
-        cooling_effect(tdb=tdb, tr=tr, vr=vr, rh=rh, met=met, clo=clo, wme=wme).ce,
-        0.0,
-    )
-
-    tdb = tdb - ce
-    tr = tr - ce
-    vr = np.where(ce > 0, 0.1, vr)
-
-    pmv_array = _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme)
-
-    ppd_array = 100.0 - 95.0 * np.exp(
-        -0.03353 * pmv_array**4.0 - 0.2179 * pmv_array**2.0,
-    )
-
-    # Calculate compliance: True if -0.5 < PMV < 0.5
-    compliance_array = (pmv_array > -0.5) & (pmv_array < 0.5)
-    # Ensure object dtype for compliance array
-    compliance_array = np.asarray(compliance_array, dtype=object)
-
-    if limit_inputs:
         all_valid = ~(
             np.isnan(tdb_valid)
             | np.isnan(tr_valid)

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -81,8 +81,8 @@ def pmv_ppd_ashrae(
 
         .. note::
             By default, if the inputs are outside the standard applicability limits, the
-            function returns nan. If False returns pmv and ppd values even if input values are
-            outside the applicability limits of the model.
+            function returns NaN. If False returns pmv and ppd
+            values even if input values are outside the applicability limits of the model.
 
             The ASHRAE 55 2020 limits are 10 < tdb [°C] < 40, 10 < tr [°C] < 40,
             0 < vr [m/s] < 2, 1 < met [met] < 4, and 0 < clo [clo] < 1.5.
@@ -173,21 +173,24 @@ def pmv_ppd_ashrae(
         )
         raise ValueError(error_msg)
 
-    (
-        tdb_valid,
-        tr_valid,
-        v_valid,
-        met_valid,
-        clo_valid,
-    ) = _check_standard_compliance_array(
-        standard=Models.ashrae_55_2023.value,
-        tdb=tdb,
-        tr=tr,
-        v=vr,
-        met=met,
-        clo=clo,
-        airspeed_control=airspeed_control,
-    )
+    # Checks that inputs are within the bounds accepted by the model if not return nan
+    # Must be done before CE correction to use the original input values
+    if limit_inputs:
+        (
+            tdb_valid,
+            tr_valid,
+            v_valid,
+            met_valid,
+            clo_valid,
+        ) = _check_standard_compliance_array(
+            standard=Models.ashrae_55_2023.value,
+            tdb=tdb,
+            tr=tr,
+            v=vr,
+            met=met,
+            clo=clo,
+            airspeed_control=airspeed_control,
+        )
 
     # if v_r is higher than 0.1 follow methodology ASHRAE Appendix H, H3
     ce = np.where(
@@ -211,7 +214,6 @@ def pmv_ppd_ashrae(
     # Ensure object dtype for compliance array
     compliance_array = np.asarray(compliance_array, dtype=object)
 
-    # Checks that inputs are within the bounds accepted by the model if not return nan
     if limit_inputs:
         all_valid = ~(
             np.isnan(tdb_valid)

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -10,7 +10,7 @@ from pythermalcomfort.shared_functions import _finalize_scalar_or_array, mapping
 from pythermalcomfort.utilities import (
     Models,
     Units,
-    _check_standard_compliance_array,
+    _check_ashrae55_compliance,
     units_converter,
 )
 
@@ -202,14 +202,14 @@ def pmv_ppd_ashrae(
             v_valid,
             met_valid,
             clo_valid,
-        ) = _check_standard_compliance_array(
-            standard=Models.ashrae_55_2023.value,
+        ) = _check_ashrae55_compliance(
             tdb=tdb,
             tr=tr,
             v=vr,
             met=met,
             clo=clo,
             airspeed_control=airspeed_control,
+            v_param_name="vr",
         )
         all_valid = ~(
             np.isnan(tdb_valid)

--- a/pythermalcomfort/models/pmv_ppd_iso.py
+++ b/pythermalcomfort/models/pmv_ppd_iso.py
@@ -9,7 +9,6 @@ from pythermalcomfort.shared_functions import mapping, valid_range
 from pythermalcomfort.utilities import (
     Models,
     Units,
-    _check_standard_compliance_array,
     units_converter,
 )
 
@@ -162,29 +161,21 @@ def pmv_ppd_iso(
             "PMV calculations can only be performed in compliance with ISO 7730-2005",
         )
 
-    pmv_array = _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme)
+    pmv = _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme)
 
     ppd_array = 100.0 - 95.0 * np.exp(
-        -0.03353 * pmv_array**4.0 - 0.2179 * pmv_array**2.0,
+        -0.03353 * pmv**4.0 - 0.2179 * pmv**2.0,
     )
 
     # Checks that inputs are within the bounds accepted by the model if not return nan
     if limit_inputs:
-        (
-            tdb_valid,
-            tr_valid,
-            v_valid,
-            met_valid,
-            clo_valid,
-        ) = _check_standard_compliance_array(
-            standard=Models.iso_7730_2005.value,
-            tdb=tdb,
-            tr=tr,
-            v=vr,
-            met=met,
-            clo=clo,
-        )
-        pmv_valid = valid_range(pmv_array, (-2, 2))  # this is the ISO limit
+        # ISO 7730-2005 page 3 applicability limits
+        tdb_valid = valid_range(tdb, (10.0, 30.0))
+        tr_valid = valid_range(tr, (10.0, 40.0))
+        v_valid = valid_range(vr, (0.0, 1.0))
+        met_valid = valid_range(met, (0.8, 4.0))
+        clo_valid = valid_range(clo, (0.0, 2.0))
+        pmv_valid = valid_range(pmv, (-2, 2))
 
         all_valid = ~(
             np.isnan(tdb_valid)
@@ -194,11 +185,11 @@ def pmv_ppd_iso(
             | np.isnan(clo_valid)
             | np.isnan(pmv_valid)
         )
-        pmv_array = np.where(all_valid, pmv_array, np.nan)
+        pmv = np.where(all_valid, pmv, np.nan)
         ppd_array = np.where(all_valid, ppd_array, np.nan)
 
     if round_output:
-        pmv_array = np.round(pmv_array, 2)
+        pmv = np.round(pmv, 2)
         ppd_array = np.round(ppd_array, 1)
 
     thermal_sensation = {
@@ -212,7 +203,7 @@ def pmv_ppd_iso(
     }
 
     return PMVPPD(
-        pmv=pmv_array,
+        pmv=pmv,
         ppd=ppd_array,
-        tsv=mapping(pmv_array, thermal_sensation, right=False),
+        tsv=mapping(pmv, thermal_sensation, right=False),
     )

--- a/pythermalcomfort/models/pmv_ppd_iso.py
+++ b/pythermalcomfort/models/pmv_ppd_iso.py
@@ -162,21 +162,6 @@ def pmv_ppd_iso(
             "PMV calculations can only be performed in compliance with ISO 7730-2005",
         )
 
-    (
-        tdb_valid,
-        tr_valid,
-        v_valid,
-        met_valid,
-        clo_valid,
-    ) = _check_standard_compliance_array(
-        standard=Models.iso_7730_2005.value,
-        tdb=tdb,
-        tr=tr,
-        v=vr,
-        met=met,
-        clo=clo,
-    )
-
     pmv_array = _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme)
 
     ppd_array = 100.0 - 95.0 * np.exp(
@@ -185,6 +170,20 @@ def pmv_ppd_iso(
 
     # Checks that inputs are within the bounds accepted by the model if not return nan
     if limit_inputs:
+        (
+            tdb_valid,
+            tr_valid,
+            v_valid,
+            met_valid,
+            clo_valid,
+        ) = _check_standard_compliance_array(
+            standard=Models.iso_7730_2005.value,
+            tdb=tdb,
+            tr=tr,
+            v=vr,
+            met=met,
+            clo=clo,
+        )
         pmv_valid = valid_range(pmv_array, (-2, 2))  # this is the ISO limit
 
         all_valid = ~(

--- a/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
+++ b/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
@@ -182,11 +182,11 @@ def _check_ridge_regression_compliance(
         Five arrays with valid values preserved and out-of-range values set to NaN:
         (age_valid, height_valid, weight_valid, temp_valid, rh_valid).
     """
-    age_valid = valid_range(age, (60, 100))
-    height_valid = valid_range(height, (130, 230))
-    weight_valid = valid_range(weight, (40, 140))
-    temp_valid = valid_range(tdb, (0, 60))
-    rh_valid = valid_range(rh, (0, 100))
+    age_valid = valid_range(age, (60, 100), "age")
+    height_valid = valid_range(height, (130, 230), "height")
+    weight_valid = valid_range(weight, (40, 140), "weight")
+    temp_valid = valid_range(tdb, (0, 60), "tdb")
+    rh_valid = valid_range(rh, (0, 100), "rh")
     return age_valid, height_valid, weight_valid, temp_valid, rh_valid
 
 

--- a/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
+++ b/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
@@ -182,11 +182,11 @@ def _check_ridge_regression_compliance(
         Five arrays with valid values preserved and out-of-range values set to NaN:
         (age_valid, height_valid, weight_valid, temp_valid, rh_valid).
     """
-    age_valid = valid_range(age, (60, 100), "age")
-    height_valid = valid_range(height, (130, 230), "height")
-    weight_valid = valid_range(weight, (40, 140), "weight")
-    temp_valid = valid_range(tdb, (0, 60), "tdb")
-    rh_valid = valid_range(rh, (0, 100), "rh")
+    age_valid = valid_range(age, (60, 100))
+    height_valid = valid_range(height, (130, 230))
+    weight_valid = valid_range(weight, (40, 140))
+    temp_valid = valid_range(tdb, (0, 60))
+    rh_valid = valid_range(rh, (0, 100))
     return age_valid, height_valid, weight_valid, temp_valid, rh_valid
 
 

--- a/pythermalcomfort/models/set_tmp.py
+++ b/pythermalcomfort/models/set_tmp.py
@@ -6,9 +6,8 @@ from pythermalcomfort.classes_input import SETInputs
 from pythermalcomfort.classes_return import SET
 from pythermalcomfort.models.two_nodes_gagge import two_nodes_gagge
 from pythermalcomfort.utilities import (
-    Models,
     Postures,
-    _check_standard_compliance_array,
+    _check_ashrae55_compliance,
 )
 
 
@@ -137,8 +136,7 @@ def set_tmp(
             v_valid,
             met_valid,
             clo_valid,
-        ) = _check_standard_compliance_array(
-            standard=Models.ashrae_55_2023.value,
+        ) = _check_ashrae55_compliance(
             tdb=tdb,
             tr=tr,
             v=v,

--- a/pythermalcomfort/models/use_fans_heatwaves.py
+++ b/pythermalcomfort/models/use_fans_heatwaves.py
@@ -7,10 +7,8 @@ import numpy as np
 from pythermalcomfort.classes_input import UseFansHeatwavesInputs
 from pythermalcomfort.classes_return import UseFansHeatwaves
 from pythermalcomfort.models.two_nodes_gagge import two_nodes_gagge
-from pythermalcomfort.utilities import (
-    Postures,
-    _check_standard_compliance_array,
-)
+from pythermalcomfort.shared_functions import valid_range
+from pythermalcomfort.utilities import Postures
 
 
 def use_fans_heatwaves(
@@ -178,22 +176,15 @@ def use_fans_heatwaves(
     output = {key: output[key] for key in output_vars}
 
     if limit_inputs:
-        (
-            tdb_valid,
-            tr_valid,
-            v_valid,
-            rh_valid,
-            met_valid,
-            clo_valid,
-        ) = _check_standard_compliance_array(
-            standard="fan_heatwaves",
-            tdb=tdb,
-            tr=tr,
-            v=v,
-            rh=rh,
-            met=met,
-            clo=clo,
-        )
+        # fan_heatwaves applicability limits (extended from ASHRAE 55 baseline).
+        tdb_valid = valid_range(tdb, (20.0, 50.0))
+        tr_valid = valid_range(tr, (20.0, 50.0))
+        v_valid = valid_range(v, (0.1, 4.5))
+        # rh is range-checked for its side-effect warning but is not included
+        # in all_valid (matches the function's prior behaviour).
+        valid_range(rh, (0, 100))
+        met_valid = valid_range(met, (0.7, 2.0))
+        clo_valid = valid_range(clo, (0.0, 1.0))
         all_valid = ~(
             np.isnan(tdb_valid)
             | np.isnan(tr_valid)

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -114,9 +114,9 @@ def utci(
 
     # Checks that inputs are within the bounds accepted by the model if not return nan
     if limit_inputs:
-        tdb_valid = valid_range(tdb, (-50.0, 50.0))
-        diff_valid = valid_range(tr - tdb, (-30.0, 70.0))
-        v_valid = valid_range(v, (0.5, 17.0))
+        tdb_valid = valid_range(tdb, (-50.0, 50.0), "tdb")
+        diff_valid = valid_range(tr - tdb, (-30.0, 70.0), "tr - tdb")
+        v_valid = valid_range(v, (0.5, 17.0), "v")
         all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
         utci_approx = np.where(all_valid, utci_approx, np.nan)
 

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -114,9 +114,9 @@ def utci(
 
     # Checks that inputs are within the bounds accepted by the model if not return nan
     if limit_inputs:
-        tdb_valid = valid_range(tdb, (-50.0, 50.0), "tdb")
-        diff_valid = valid_range(tr - tdb, (-30.0, 70.0), "tr - tdb")
-        v_valid = valid_range(v, (0.5, 17.0), "v")
+        tdb_valid = valid_range(tdb, (-50.0, 50.0))
+        diff_valid = valid_range(tr - tdb, (-30.0, 70.0), param_name="tr - tdb")
+        v_valid = valid_range(v, (0.5, 17.0))
         all_valid = ~(np.isnan(tdb_valid) | np.isnan(diff_valid) | np.isnan(v_valid))
         utci_approx = np.where(all_valid, utci_approx, np.nan)
 

--- a/pythermalcomfort/models/vertical_tmp_grad_ppd.py
+++ b/pythermalcomfort/models/vertical_tmp_grad_ppd.py
@@ -17,6 +17,7 @@ def vertical_tmp_grad_ppd(
     clo: float | list[float],
     vertical_tmp_grad: float | list[float],
     round_output: bool = True,
+    limit_inputs: bool = True,
 ) -> VerticalTGradPPD:
     """Calculate the percentage of thermally dissatisfied people with a vertical
     temperature gradient between feet and head [55ASHRAE2023]_. This equation is only
@@ -64,6 +65,12 @@ def vertical_tmp_grad_ppd(
         Vertical temperature gradient between the feet and the head, [°C/m].
     round_output : bool, optional
         If True, rounds output value. If False, it does not round it. Defaults to True.
+    limit_inputs : bool, optional
+        By default, if the inputs are outside the standard applicability limits the
+        function returns nan. If False, returns values even if input values are
+        outside the applicability limits of the model. Defaults to True. The
+        applicability limits are 10 < tdb [°C] < 40, 10 < tr [°C] < 40,
+        0 < vr [m/s] < 0.2, 1 < met [met] < 4, and 0 < clo [clo] < 1.5.
 
     Returns
     -------
@@ -93,6 +100,7 @@ def vertical_tmp_grad_ppd(
         met=met,
         clo=clo,
         vertical_tmp_grad=vertical_tmp_grad,
+        limit_inputs=limit_inputs,
     )
 
     tdb = np.asarray(tdb)
@@ -101,20 +109,6 @@ def vertical_tmp_grad_ppd(
     met = np.asarray(met)
     clo = np.asarray(clo)
     vertical_tmp_grad = np.asarray(vertical_tmp_grad)
-
-    (
-        tdb_valid,
-        tr_valid,
-        v_valid,
-        met_valid,
-        clo_valid,
-    ) = _check_ashrae55_compliance(
-        tdb=tdb,
-        tr=tr,
-        v_limited=vr,
-        met=met,
-        clo=clo,
-    )
 
     tsv = pmv_ppd_ashrae(
         tdb=tdb,
@@ -133,15 +127,30 @@ def vertical_tmp_grad_ppd(
     if round_output:
         ppd_val = np.round(ppd_val, 1)
 
-    all_valid = ~(
-        np.isnan(tdb_valid)
-        | np.isnan(tr_valid)
-        | np.isnan(v_valid)
-        | np.isnan(met_valid)
-        | np.isnan(clo_valid)
-    )
+    if limit_inputs:
+        (
+            tdb_valid,
+            tr_valid,
+            met_valid,
+            clo_valid,
+            v_limited_valid,
+        ) = _check_ashrae55_compliance(
+            tdb=tdb,
+            tr=tr,
+            v_limited=vr,
+            met=met,
+            clo=clo,
+        )
 
-    ppd_val = np.where(all_valid, ppd_val, np.nan)
-    acceptability = np.where(all_valid, acceptability, np.nan)
+        all_valid = ~(
+            np.isnan(tdb_valid)
+            | np.isnan(tr_valid)
+            | np.isnan(met_valid)
+            | np.isnan(clo_valid)
+            | np.isnan(v_limited_valid)
+        )
+
+        ppd_val = np.where(all_valid, ppd_val, np.nan)
+        acceptability = np.where(all_valid, acceptability, np.nan)
 
     return VerticalTGradPPD(ppd_vg=ppd_val, acceptability=acceptability)

--- a/pythermalcomfort/models/vertical_tmp_grad_ppd.py
+++ b/pythermalcomfort/models/vertical_tmp_grad_ppd.py
@@ -125,6 +125,7 @@ def vertical_tmp_grad_ppd(
         met=met,
         clo=clo,
         model=Models.ashrae_55_2023.value,
+        limit_inputs=False,
     ).pmv
     numerator = np.exp(0.13 * (tsv - 1.91) ** 2 + 0.15 * vertical_tmp_grad - 1.6)
     ppd_val = (numerator / (1 + numerator) - 0.345) * 100

--- a/pythermalcomfort/models/vertical_tmp_grad_ppd.py
+++ b/pythermalcomfort/models/vertical_tmp_grad_ppd.py
@@ -5,7 +5,7 @@ import numpy as np
 from pythermalcomfort.classes_input import VerticalTGradPPDInputs
 from pythermalcomfort.classes_return import VerticalTGradPPD
 from pythermalcomfort.models import pmv_ppd_ashrae
-from pythermalcomfort.utilities import Models, _check_standard_compliance_array
+from pythermalcomfort.utilities import Models, _check_ashrae55_compliance
 
 
 def vertical_tmp_grad_ppd(
@@ -108,8 +108,7 @@ def vertical_tmp_grad_ppd(
         v_valid,
         met_valid,
         clo_valid,
-    ) = _check_standard_compliance_array(
-        standard=Models.ashrae_55_2023.value,
+    ) = _check_ashrae55_compliance(
         tdb=tdb,
         tr=tr,
         v_limited=vr,

--- a/pythermalcomfort/shared_functions.py
+++ b/pythermalcomfort/shared_functions.py
@@ -1,3 +1,5 @@
+import ast
+import inspect
 import warnings
 from collections.abc import Mapping
 from typing import Any
@@ -5,32 +7,133 @@ from typing import Any
 import numpy as np
 
 
-def valid_range(x, valid, param_name=None) -> np.ndarray:
-    """Filter values based on a valid range."""
+def valid_range(
+    x,
+    valid: tuple[float, float],
+    param_name: str | None = None,
+) -> np.ndarray:
+    """Filter values based on a valid range, warning on out-of-range entries.
+
+    Parameters
+    ----------
+    x : float or array-like
+        Value(s) to validate.
+    valid : tuple[float, float]
+        Inclusive lower and upper bounds of the applicability range.
+    param_name : str, optional
+        Label for the parameter, used in the UserWarning text. When omitted,
+        the name is auto-extracted from the caller's source via frame
+        inspection. Pass ``param_name`` explicitly when the first argument is
+        an expression, a subscript, or a literal — frame inspection only
+        recovers bare variable names.
+
+    Returns
+    -------
+    np.ndarray
+        Array with out-of-range entries replaced by ``np.nan``.
+
+    Warns
+    -----
+    UserWarning
+        Emitted when any element falls outside ``valid``. Example messages::
+
+            'tdb' has value 50.0 outside the applicability limits [10.0, 40.0] and will be set to NaN.
+            'tdb' has 2 values [50.0, 45.0] at indices [1, 3] outside the applicability limits [10.0, 40.0] and will be set to NaN.
+    """
+    if param_name is None:
+        param_name = _extract_caller_argname() or "<unknown>"
+
     x_arr = np.asarray(x)
     out_of_range_mask = (x_arr < valid[0]) | (x_arr > valid[1])
 
-    if param_name is not None and np.any(out_of_range_mask):
-        if x_arr.ndim == 0:  # scalar input
-            warnings.warn(
-                f"Value of '{param_name}' ({float(x_arr.item())}) is outside the "
-                f"applicability limits [{valid[0]}, {valid[1]}] and will be "
-                f"set to NaN.",
-                UserWarning,
-                stacklevel=2,
-            )
-        else:  # array input
-            bad_indices = np.flatnonzero(out_of_range_mask).tolist()
-            bad_values = x_arr[out_of_range_mask].tolist()
-            warnings.warn(
-                f"Some values of '{param_name}' are outside the applicability "
-                f"limits [{valid[0]}, {valid[1]}] and will be set to NaN. "
-                f"Out-of-range values: {bad_values} at indices {bad_indices}.",
-                UserWarning,
-                stacklevel=2,
-            )
+    if np.any(out_of_range_mask):
+        detail = _format_violation_detail(x_arr, out_of_range_mask)
+        msg = (
+            f"'{param_name}' has {detail} outside the applicability "
+            f"limits [{valid[0]}, {valid[1]}] and will be set to NaN."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=2)
 
     return np.where(~out_of_range_mask, x_arr, np.nan)
+
+
+def _format_violation_detail(x_arr: np.ndarray, mask: np.ndarray) -> str:
+    """Format the detail portion of a UserWarning describing out-of-range values.
+
+    Shared by :func:`valid_range` and by the ASHRAE 55 ``airspeed_control``
+    checks so warning bodies stay consistent.
+
+    Output formats
+    --------------
+    Scalar (0-d) input::
+
+        value 50.0
+
+    Array input::
+
+        1 value [50.0] at indices [0]
+        2 values [50.0, 45.0] at indices [1, 3]
+    """
+    if x_arr.ndim == 0:
+        return f"value {float(x_arr.item())}"
+    n_bad = int(mask.sum())
+    bad_values = x_arr[mask].tolist()
+    bad_indices = np.flatnonzero(mask).tolist()
+    noun = "value" if n_bad == 1 else "values"
+    return f"{n_bad} {noun} {bad_values} at indices {bad_indices}"
+
+
+def _extract_caller_argname() -> str | None:
+    """Return the name of the first positional argument of the caller's ``valid_range``
+    call, or ``None`` if it cannot be recovered.
+
+    The caller's source is inspected via :mod:`inspect` and parsed with :mod:`ast`.
+    ``None`` is returned when the source is unavailable (e.g. code compiled without
+    source, some REPL contexts) or when the first argument is not a bare ``Name`` node
+    (e.g. expressions, subscripts, literals). Callers should pass ``param_name``
+    explicitly in those cases.
+    """
+    frame = inspect.currentframe()
+    try:
+        if frame is None or frame.f_back is None or frame.f_back.f_back is None:
+            return None
+        caller = frame.f_back.f_back
+        info = inspect.getframeinfo(caller, context=10)
+        if not info.code_context or info.index is None:
+            return None
+        lines = info.code_context
+        idx = info.index
+        n = len(lines)
+
+        # Try parseable windows containing idx, growing outward from the
+        # call line. Smaller windows are tried first so an unrelated nearby
+        # call cannot be mistaken for the active one.
+        windows = [(idx, idx + 1)]
+        for radius in range(1, max(idx, n - idx - 1) + 1):
+            start = max(0, idx - radius)
+            end = min(n, idx + radius + 1)
+            windows.append((start, end))
+
+        for start, end in windows:
+            src = "".join(lines[start:end]).strip()
+            if not src:
+                continue
+            try:
+                tree = ast.parse(src)
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "valid_range"
+                    and node.args
+                    and isinstance(node.args[0], ast.Name)
+                ):
+                    return node.args[0].id
+        return None
+    finally:
+        del frame
 
 
 def _finalize_scalar_or_array(arr: Any) -> Any:

--- a/pythermalcomfort/shared_functions.py
+++ b/pythermalcomfort/shared_functions.py
@@ -1,12 +1,36 @@
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 
 
-def valid_range(x, valid) -> np.ndarray:
+def valid_range(x, valid, param_name=None) -> np.ndarray:
     """Filter values based on a valid range."""
-    return np.where((x >= valid[0]) & (x <= valid[1]), x, np.nan)
+    x_arr = np.asarray(x)
+    out_of_range_mask = (x_arr < valid[0]) | (x_arr > valid[1])
+
+    if param_name is not None and np.any(out_of_range_mask):
+        if x_arr.ndim == 0:  # scalar input
+            warnings.warn(
+                f"Value of '{param_name}' ({float(x_arr.item())}) is outside the "
+                f"applicability limits [{valid[0]}, {valid[1]}] and will be "
+                f"set to NaN.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:  # array input
+            bad_indices = np.flatnonzero(out_of_range_mask).tolist()
+            bad_values = x_arr[out_of_range_mask].tolist()
+            warnings.warn(
+                f"Some values of '{param_name}' are outside the applicability "
+                f"limits [{valid[0]}, {valid[1]}] and will be set to NaN. "
+                f"Out-of-range values: {bad_values} at indices {bad_indices}.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    return np.where(~out_of_range_mask, x_arr, np.nan)
 
 
 def _finalize_scalar_or_array(arr: Any) -> Any:

--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pythermalcomfort.classes_return import PsychrometricValues
-from pythermalcomfort.shared_functions import valid_range
+from pythermalcomfort.shared_functions import _format_violation_detail, valid_range
 
 warnings.simplefilter("always")
 
@@ -396,7 +396,7 @@ def mean_radiant_tmp(
             - 273.15
         )
 
-        d_valid = valid_range(d, (0.04, 0.15), "d")
+        d_valid = valid_range(d, (0.04, 0.15))
         return np.where(~np.isnan(d_valid), tr, np.nan)
 
     if standard == "iso":  # pragma: no branch
@@ -450,125 +450,100 @@ def transpose_sharp_altitude(sharp: float, altitude: float) -> tuple[float, floa
     return round(sharp, 3), round(sol_altitude, 3)
 
 
-def _check_standard_compliance_array(standard, **kwargs):
-    default_kwargs = {"airspeed_control": True}
+def _check_ashrae55_compliance(**kwargs):
+    """ASHRAE 55-2023 input applicability check.
+
+    Implements the Table 7.3.4 single-variable limits and the §7.2.1.2
+    ``airspeed_control`` cross-variable rules. Single-use compliance checks for other
+    standards (ISO 7730, ISO 7933, fan_heatwaves) live inline in the respective model
+    files.
+
+    ``v_param_name`` (default ``"v"``) controls how the airspeed variable is rendered in
+    UserWarnings emitted by this function. Callers whose signature names the airspeed
+    argument ``vr`` should pass ``v_param_name="vr"`` so the warning text matches the
+    caller's variable name. It does not affect which value is checked.
+    """
+    default_kwargs = {"airspeed_control": True, "v_param_name": "v"}
     params = {**default_kwargs, **kwargs}
+    v_param_name = params["v_param_name"]
     values_to_return = {}
 
-    if standard == Models.ashrae_55_2023.value:  # based on table 7.3.4 ashrae 55 2020
-        tdb_valid = valid_range(params["tdb"], (10.0, 40.0), "tdb")
-        tr_valid = valid_range(params["tr"], (10.0, 40.0), "tr")
+    tdb_valid = valid_range(params["tdb"], (10.0, 40.0), param_name="tdb")
+    tr_valid = valid_range(params["tr"], (10.0, 40.0), param_name="tr")
 
-        values_to_return["tdb"] = tdb_valid
-        values_to_return["tr"] = tr_valid
+    values_to_return["tdb"] = tdb_valid
+    values_to_return["tr"] = tr_valid
 
-        if "v" in params:
-            v_valid = valid_range(params["v"], (0.0, 2.0), "v")
-            values_to_return["v"] = v_valid
+    if "v" in params:
+        v_valid = valid_range(params["v"], (0.0, 2.0), param_name=v_param_name)
+        values_to_return["v"] = v_valid
 
-        if not params["airspeed_control"]:
-            cond1 = (params["v"] > 0.8) & (params["clo"] < 0.7) & (params["met"] < 1.3)
-            if np.any(cond1):
-                warnings.warn(
-                    f"airspeed_control=False: some values of 'v' exceed 0.8 m/s "
-                    f"under low clothing (clo < 0.7) and low activity (met < 1.3) "
-                    f"conditions and will be set to NaN. "
-                    f"Affected indices: {np.flatnonzero(cond1).tolist()}.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            v_valid = np.where(cond1, np.nan, v_valid)
-
-            to = operative_tmp(params["tdb"], params["tr"], params["v"])
-            v_limit = 50.49 - 4.4047 * to + 0.096425 * to * to
-
-            cond2 = (
-                (to > 23)
-                & (to < 25.5)
-                & (params["v"] > v_limit)
-                & (params["clo"] < 0.7)
-                & (params["met"] < 1.3)
+    if not params["airspeed_control"]:
+        v_arr = np.asarray(params["v"])
+        cond1 = (params["v"] > 0.8) & (params["clo"] < 0.7) & (params["met"] < 1.3)
+        if np.any(cond1):
+            detail = _format_violation_detail(v_arr, cond1)
+            warnings.warn(
+                f"airspeed_control=False: '{v_param_name}' has {detail} exceeding "
+                f"0.8 m/s under low clothing (clo < 0.7) and low activity "
+                f"(met < 1.3) and will be set to NaN.",
+                UserWarning,
+                stacklevel=2,
             )
-            if np.any(cond2):
-                warnings.warn(
-                    f"airspeed_control=False: some values of 'v' exceed the ASHRAE 55 "
-                    f"airspeed limit in the comfort zone (23°C < to < 25.5°C) and will "
-                    f"be set to NaN. "
-                    f"Affected indices: {np.flatnonzero(cond2).tolist()}.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            v_valid = np.where(cond2, np.nan, v_valid)
+        v_valid = np.where(cond1, np.nan, v_valid)
 
-            cond3 = (
-                (to <= 23)
-                & (params["v"] > 0.2)
-                & (params["clo"] < 0.7)
-                & (params["met"] < 1.3)
+        to = operative_tmp(params["tdb"], params["tr"], params["v"])
+        v_limit = 50.49 - 4.4047 * to + 0.096425 * to * to
+
+        cond2 = (
+            (to > 23)
+            & (to < 25.5)
+            & (params["v"] > v_limit)
+            & (params["clo"] < 0.7)
+            & (params["met"] < 1.3)
+        )
+        if np.any(cond2):
+            detail = _format_violation_detail(v_arr, cond2)
+            warnings.warn(
+                f"airspeed_control=False: '{v_param_name}' has {detail} exceeding "
+                f"the ASHRAE 55 airspeed limit in the comfort zone "
+                f"(23°C < to < 25.5°C) and will be set to NaN.",
+                UserWarning,
+                stacklevel=2,
             )
-            if np.any(cond3):
-                warnings.warn(
-                    f"airspeed_control=False: some values of 'v' exceed 0.2 m/s when "
-                    f"operative temperature is ≤ 23°C and will be set to NaN. "
-                    f"Affected indices: {np.flatnonzero(cond3).tolist()}.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            v_valid = np.where(cond3, np.nan, v_valid)
+        v_valid = np.where(cond2, np.nan, v_valid)
 
-            values_to_return["v"] = v_valid
+        cond3 = (
+            (to <= 23)
+            & (params["v"] > 0.2)
+            & (params["clo"] < 0.7)
+            & (params["met"] < 1.3)
+        )
+        if np.any(cond3):
+            detail = _format_violation_detail(v_arr, cond3)
+            warnings.warn(
+                f"airspeed_control=False: '{v_param_name}' has {detail} exceeding "
+                f"0.2 m/s when operative temperature is ≤ 23°C and will be set "
+                f"to NaN.",
+                UserWarning,
+                stacklevel=2,
+            )
+        v_valid = np.where(cond3, np.nan, v_valid)
 
-        if "met" in params:
-            met_valid = valid_range(params["met"], (1.0, 4.0), "met")
-            clo_valid = valid_range(params["clo"], (0.0, 1.5), "clo")
+        values_to_return["v"] = v_valid
 
-            values_to_return["met"] = met_valid
-            values_to_return["clo"] = clo_valid
+    if "met" in params:
+        met_valid = valid_range(params["met"], (1.0, 4.0), param_name="met")
+        clo_valid = valid_range(params["clo"], (0.0, 1.5), param_name="clo")
 
-        if "v_limited" in params:
-            valid = valid_range(params["v_limited"], (0.0, 0.2), "v_limited")
-            values_to_return["v_limited"] = valid
+        values_to_return["met"] = met_valid
+        values_to_return["clo"] = clo_valid
 
-        return values_to_return.values()
+    if "v_limited" in params:
+        valid = valid_range(params["v_limited"], (0.0, 0.2), param_name="v_limited")
+        values_to_return["v_limited"] = valid
 
-    if standard == Models.iso_7933_2004.value:  # based on ISO 7933:2004 Annex A
-        tdb_valid = valid_range(params["tdb"], (15.0, 50.0), "tdb")
-        p_a_valid = valid_range(params["p_a"], (0, 4.5), "p_a")
-        tr_valid = valid_range(params["tr"], (0.0, 60.0), "tr")
-        v_valid = valid_range(params["v"], (0.0, 3), "v")
-        met_valid = valid_range(params["met"], (100, 450), "met")
-        clo_valid = valid_range(params["clo"], (0.1, 1), "clo")
-
-        return tdb_valid, tr_valid, v_valid, p_a_valid, met_valid, clo_valid
-
-    if standard == Models.iso_7933_2023.value:  # based on ISO 7933:2023 Annex A
-        tdb_valid = valid_range(params["tdb"], (15.0, 50.0), "tdb")
-        p_a_valid = valid_range(params["p_a"], (0.5, 4.5), "p_a")
-        tr_valid = valid_range(params["tr"], (0.0, 60.0), "tr")
-        v_valid = valid_range(params["v"], (0.0, 3), "v")
-        met_valid = valid_range(params["met"], (100, 450), "met")
-        clo_valid = valid_range(params["clo"], (0.1, 1), "clo")
-
-        return tdb_valid, tr_valid, v_valid, p_a_valid, met_valid, clo_valid
-
-    if standard == "fan_heatwaves":
-        tdb_valid = valid_range(params["tdb"], (20.0, 50.0), "tdb")
-        tr_valid = valid_range(params["tr"], (20.0, 50.0), "tr")
-        v_valid = valid_range(params["v"], (0.1, 4.5), "v")
-        rh_valid = valid_range(params["rh"], (0, 100), "rh")
-        met_valid = valid_range(params["met"], (0.7, 2), "met")
-        clo_valid = valid_range(params["clo"], (0.0, 1), "clo")
-
-        return tdb_valid, tr_valid, v_valid, rh_valid, met_valid, clo_valid
-
-    if standard == Models.iso_7730_2005.value:  # based on ISO 7730:2005 page 3
-        tdb_valid = valid_range(params["tdb"], (10.0, 30.0), "tdb")
-        tr_valid = valid_range(params["tr"], (10.0, 40.0), "tr")
-        v_valid = valid_range(params["v"], (0.0, 1.0), "v")
-        met_valid = valid_range(params["met"], (0.8, 4.0), "met")
-        clo_valid = valid_range(params["clo"], (0.0, 2), "clo")
-
-        return tdb_valid, tr_valid, v_valid, met_valid, clo_valid
+    return values_to_return.values()
 
 
 class Postures(Enum):

--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -103,7 +103,6 @@ def p_sat(tdb: float | list[float] | NDArray[np.float64]) -> NDArray[np.float64]
     p_sat: float or list of floats
         saturation vapor pressure, [Pa]
     """
-
     # pre-calculated constants for p_sat
     c1 = -5674.5359
     c2 = 6.3925247
@@ -228,7 +227,6 @@ def wet_bulb_tmp(
     tdb: float or list of floats
         wet-bulb temperature, [°C]
     """
-
     tdb = np.asarray(tdb, dtype=np.float64)
     rh = np.asarray(rh, dtype=np.float64)
 
@@ -398,7 +396,7 @@ def mean_radiant_tmp(
             - 273.15
         )
 
-        d_valid = valid_range(d, (0.04, 0.15))
+        d_valid = valid_range(d, (0.04, 0.15), "d")
         return np.where(~np.isnan(d_valid), tr, np.nan)
 
     if standard == "iso":  # pragma: no branch
@@ -458,93 +456,117 @@ def _check_standard_compliance_array(standard, **kwargs):
     values_to_return = {}
 
     if standard == Models.ashrae_55_2023.value:  # based on table 7.3.4 ashrae 55 2020
-        tdb_valid = valid_range(params["tdb"], (10.0, 40.0))
-        tr_valid = valid_range(params["tr"], (10.0, 40.0))
+        tdb_valid = valid_range(params["tdb"], (10.0, 40.0), "tdb")
+        tr_valid = valid_range(params["tr"], (10.0, 40.0), "tr")
 
         values_to_return["tdb"] = tdb_valid
         values_to_return["tr"] = tr_valid
 
         if "v" in params:
-            v_valid = valid_range(params["v"], (0.0, 2.0))
+            v_valid = valid_range(params["v"], (0.0, 2.0), "v")
             values_to_return["v"] = v_valid
 
         if not params["airspeed_control"]:
-            v_valid = np.where(
-                (params["v"] > 0.8) & (params["clo"] < 0.7) & (params["met"] < 1.3),
-                np.nan,
-                v_valid,
-            )
+            cond1 = (params["v"] > 0.8) & (params["clo"] < 0.7) & (params["met"] < 1.3)
+            if np.any(cond1):
+                warnings.warn(
+                    f"airspeed_control=False: some values of 'v' exceed 0.8 m/s "
+                    f"under low clothing (clo < 0.7) and low activity (met < 1.3) "
+                    f"conditions and will be set to NaN. "
+                    f"Affected indices: {np.flatnonzero(cond1).tolist()}.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            v_valid = np.where(cond1, np.nan, v_valid)
+
             to = operative_tmp(params["tdb"], params["tr"], params["v"])
             v_limit = 50.49 - 4.4047 * to + 0.096425 * to * to
-            v_valid = np.where(
+
+            cond2 = (
                 (to > 23)
                 & (to < 25.5)
                 & (params["v"] > v_limit)
                 & (params["clo"] < 0.7)
-                & (params["met"] < 1.3),
-                np.nan,
-                v_valid,
+                & (params["met"] < 1.3)
             )
-            v_valid = np.where(
+            if np.any(cond2):
+                warnings.warn(
+                    f"airspeed_control=False: some values of 'v' exceed the ASHRAE 55 "
+                    f"airspeed limit in the comfort zone (23°C < to < 25.5°C) and will "
+                    f"be set to NaN. "
+                    f"Affected indices: {np.flatnonzero(cond2).tolist()}.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            v_valid = np.where(cond2, np.nan, v_valid)
+
+            cond3 = (
                 (to <= 23)
                 & (params["v"] > 0.2)
                 & (params["clo"] < 0.7)
-                & (params["met"] < 1.3),
-                np.nan,
-                v_valid,
+                & (params["met"] < 1.3)
             )
+            if np.any(cond3):
+                warnings.warn(
+                    f"airspeed_control=False: some values of 'v' exceed 0.2 m/s when "
+                    f"operative temperature is ≤ 23°C and will be set to NaN. "
+                    f"Affected indices: {np.flatnonzero(cond3).tolist()}.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            v_valid = np.where(cond3, np.nan, v_valid)
 
             values_to_return["v"] = v_valid
 
         if "met" in params:
-            met_valid = valid_range(params["met"], (1.0, 4.0))
-            clo_valid = valid_range(params["clo"], (0.0, 1.5))
+            met_valid = valid_range(params["met"], (1.0, 4.0), "met")
+            clo_valid = valid_range(params["clo"], (0.0, 1.5), "clo")
 
             values_to_return["met"] = met_valid
             values_to_return["clo"] = clo_valid
 
         if "v_limited" in params:
-            valid = valid_range(params["v_limited"], (0.0, 0.2))
+            valid = valid_range(params["v_limited"], (0.0, 0.2), "v_limited")
             values_to_return["v_limited"] = valid
 
         return values_to_return.values()
 
     if standard == Models.iso_7933_2004.value:  # based on ISO 7933:2004 Annex A
-        tdb_valid = valid_range(params["tdb"], (15.0, 50.0))
-        p_a_valid = valid_range(params["p_a"], (0, 4.5))
-        tr_valid = valid_range(params["tr"], (0.0, 60.0))
-        v_valid = valid_range(params["v"], (0.0, 3))
-        met_valid = valid_range(params["met"], (100, 450))
-        clo_valid = valid_range(params["clo"], (0.1, 1))
+        tdb_valid = valid_range(params["tdb"], (15.0, 50.0), "tdb")
+        p_a_valid = valid_range(params["p_a"], (0, 4.5), "p_a")
+        tr_valid = valid_range(params["tr"], (0.0, 60.0), "tr")
+        v_valid = valid_range(params["v"], (0.0, 3), "v")
+        met_valid = valid_range(params["met"], (100, 450), "met")
+        clo_valid = valid_range(params["clo"], (0.1, 1), "clo")
 
         return tdb_valid, tr_valid, v_valid, p_a_valid, met_valid, clo_valid
 
     if standard == Models.iso_7933_2023.value:  # based on ISO 7933:2023 Annex A
-        tdb_valid = valid_range(params["tdb"], (15.0, 50.0))
-        p_a_valid = valid_range(params["p_a"], (0.5, 4.5))
-        tr_valid = valid_range(params["tr"], (0.0, 60.0))
-        v_valid = valid_range(params["v"], (0.0, 3))
-        met_valid = valid_range(params["met"], (100, 450))
-        clo_valid = valid_range(params["clo"], (0.1, 1))
+        tdb_valid = valid_range(params["tdb"], (15.0, 50.0), "tdb")
+        p_a_valid = valid_range(params["p_a"], (0.5, 4.5), "p_a")
+        tr_valid = valid_range(params["tr"], (0.0, 60.0), "tr")
+        v_valid = valid_range(params["v"], (0.0, 3), "v")
+        met_valid = valid_range(params["met"], (100, 450), "met")
+        clo_valid = valid_range(params["clo"], (0.1, 1), "clo")
 
         return tdb_valid, tr_valid, v_valid, p_a_valid, met_valid, clo_valid
 
     if standard == "fan_heatwaves":
-        tdb_valid = valid_range(params["tdb"], (20.0, 50.0))
-        tr_valid = valid_range(params["tr"], (20.0, 50.0))
-        v_valid = valid_range(params["v"], (0.1, 4.5))
-        rh_valid = valid_range(params["rh"], (0, 100))
-        met_valid = valid_range(params["met"], (0.7, 2))
-        clo_valid = valid_range(params["clo"], (0.0, 1))
+        tdb_valid = valid_range(params["tdb"], (20.0, 50.0), "tdb")
+        tr_valid = valid_range(params["tr"], (20.0, 50.0), "tr")
+        v_valid = valid_range(params["v"], (0.1, 4.5), "v")
+        rh_valid = valid_range(params["rh"], (0, 100), "rh")
+        met_valid = valid_range(params["met"], (0.7, 2), "met")
+        clo_valid = valid_range(params["clo"], (0.0, 1), "clo")
 
         return tdb_valid, tr_valid, v_valid, rh_valid, met_valid, clo_valid
 
     if standard == Models.iso_7730_2005.value:  # based on ISO 7730:2005 page 3
-        tdb_valid = valid_range(params["tdb"], (10.0, 30.0))
-        tr_valid = valid_range(params["tr"], (10.0, 40.0))
-        v_valid = valid_range(params["v"], (0.0, 1.0))
-        met_valid = valid_range(params["met"], (0.8, 4.0))
-        clo_valid = valid_range(params["clo"], (0.0, 2))
+        tdb_valid = valid_range(params["tdb"], (10.0, 30.0), "tdb")
+        tr_valid = valid_range(params["tr"], (10.0, 40.0), "tr")
+        v_valid = valid_range(params["v"], (0.0, 1.0), "v")
+        met_valid = valid_range(params["met"], (0.8, 4.0), "met")
+        clo_valid = valid_range(params["clo"], (0.0, 2), "clo")
 
         return tdb_valid, tr_valid, v_valid, met_valid, clo_valid
 
@@ -674,8 +696,9 @@ def clo_dynamic_ashrae(
     met: float | list[float],
     model: str = Models.ashrae_55_2023.value,
 ) -> np.ndarray:
-    """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`). The ASHRAE
-    55:2023 refers to it as (I :sub:`cl,active`). The activity as well as the air speed
+    """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`).
+
+    The ASHRAE 55:2023 refers to it as (I :sub:`cl,active`). The activity as well as the air speed
     modify the insulation characteristics of the clothing. Consequently, the ASHRAE 55
     standard provides a correction factor for the clothing insulation (I :sub:`cl`)
     based on the metabolic rate.
@@ -721,8 +744,9 @@ def clo_dynamic_iso(
     i_a: float | list[float] = 0.7,
     model: str = Models.iso_9920_2007.value,
 ) -> np.ndarray:
-    """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`). The activity
-    as well as the air speed modify the insulation characteristics of the clothing.
+    """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`).
+
+    The activity as well as the air speed modify the insulation characteristics of the clothing.
     Consequently, the ISO standard states that (I :sub:`cl,`) shall be corrected
     [7730ISO2005]_. However, the ISO 7730:2005 contains insufficient information to
     calculate (I :sub:`cl,r`). Therefore, we implemented the equations provided in the

--- a/tests/test_adaptive_ashrae.py
+++ b/tests/test_adaptive_ashrae.py
@@ -79,3 +79,73 @@ def test_nan_values_for_invalid_inputs() -> None:
     # Check that the acceptability flags are False
     assert result.acceptability_80 == False
     assert result.acceptability_90 == False
+
+
+def test_round_output_default_preserves_behaviour() -> None:
+    """Default call must match an explicit round_output=True call."""
+    default_result = adaptive_ashrae(tdb=25, tr=25, t_running_mean=21.5, v=0.1)
+    explicit_result = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert default_result.tmp_cmf == explicit_result.tmp_cmf
+    assert default_result.tmp_cmf_80_low == explicit_result.tmp_cmf_80_low
+    assert default_result.tmp_cmf_80_up == explicit_result.tmp_cmf_80_up
+    assert default_result.tmp_cmf_90_low == explicit_result.tmp_cmf_90_low
+    assert default_result.tmp_cmf_90_up == explicit_result.tmp_cmf_90_up
+
+
+def test_round_output_false_returns_unrounded() -> None:
+    """round_output=False must return unrounded t_cmf at full precision."""
+    # 0.31 * 21.5 + 17.8 = 24.465; rounded to 1 dp this is 24.5.
+    unrounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=False,
+    )
+    rounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert np.isclose(unrounded.tmp_cmf, 24.465)
+    assert np.isclose(rounded.tmp_cmf, 24.5)
+    assert unrounded.tmp_cmf != rounded.tmp_cmf
+
+
+def test_round_output_false_propagates_to_bounds() -> None:
+    """Unrounded t_cmf must propagate into the derived comfort bounds."""
+    unrounded = adaptive_ashrae(
+        tdb=25,
+        tr=25,
+        t_running_mean=21.5,
+        v=0.1,
+        round_output=False,
+    )
+
+    # tmp_cmf_80_low = t_cmf - 3.5; with unrounded t_cmf=24.465 this is 20.965.
+    assert np.isclose(unrounded.tmp_cmf_80_low, 24.465 - 3.5)
+    assert np.isclose(unrounded.tmp_cmf_90_low, 24.465 - 2.5)
+    assert np.isclose(unrounded.tmp_cmf_80_up, 24.465 + 3.5)
+    assert np.isclose(unrounded.tmp_cmf_90_up, 24.465 + 2.5)
+
+
+def test_round_output_invalid_type_raises() -> None:
+    """A non-boolean round_output must raise TypeError."""
+    with pytest.raises(TypeError):
+        adaptive_ashrae(
+            tdb=25,
+            tr=25,
+            t_running_mean=20,
+            v=0.1,
+            round_output="yes",
+        )

--- a/tests/test_adaptive_en.py
+++ b/tests/test_adaptive_en.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pythermalcomfort.models import adaptive_en
@@ -54,3 +55,54 @@ def test_ashrae_inputs_invalid_v_type() -> None:
     """Test that the function raises a TypeError for invalid v type."""
     with pytest.raises(TypeError):
         adaptive_en(tdb=25, tr=25, t_running_mean=20, v="invalid")
+
+
+def test_round_output_default_preserves_behaviour() -> None:
+    """Default call must match an explicit round_output=True call."""
+    default_result = adaptive_en(tdb=25, tr=25, t_running_mean=20.5, v=0.1)
+    explicit_result = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert default_result.tmp_cmf == explicit_result.tmp_cmf
+    assert default_result.tmp_cmf_cat_i_up == explicit_result.tmp_cmf_cat_i_up
+    assert default_result.tmp_cmf_cat_i_low == explicit_result.tmp_cmf_cat_i_low
+    assert default_result.tmp_cmf_cat_ii_up == explicit_result.tmp_cmf_cat_ii_up
+    assert default_result.tmp_cmf_cat_iii_low == explicit_result.tmp_cmf_cat_iii_low
+
+
+def test_round_output_false_returns_unrounded() -> None:
+    """round_output=False must return unrounded t_cmf and bounds at full precision."""
+    # 0.33 * 20.5 + 18.8 = 25.565; rounded to 1 dp this is 25.6.
+    unrounded = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=False,
+    )
+    rounded = adaptive_en(
+        tdb=25,
+        tr=25,
+        t_running_mean=20.5,
+        v=0.1,
+        round_output=True,
+    )
+
+    assert np.isclose(unrounded.tmp_cmf, 25.565)
+    assert np.isclose(rounded.tmp_cmf, 25.6)
+    assert unrounded.tmp_cmf != rounded.tmp_cmf
+
+    # Bounds derive from the unrounded value when round_output=False.
+    assert np.isclose(unrounded.tmp_cmf_cat_i_low, 25.565 - 3.0)
+    assert np.isclose(unrounded.tmp_cmf_cat_ii_up, 25.565 + 3.0)
+
+
+def test_round_output_invalid_type_raises() -> None:
+    """A non-boolean round_output must raise TypeError."""
+    with pytest.raises(TypeError):
+        adaptive_en(tdb=25, tr=25, t_running_mean=20, v=0.1, round_output="yes")

--- a/tests/test_ankle_draft.py
+++ b/tests/test_ankle_draft.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -72,3 +74,25 @@ def test_ankle_draft_invalid_list_inputs() -> None:
             v_ankle=[0.1, 0.1, 0.1],
             units=Units.SI.value,
         )
+
+
+def test_ankle_draft_limit_inputs_false_suppresses_warning_and_nan() -> None:
+    """limit_inputs=False bypasses range checks: no UserWarning, no NaN mask."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = ankle_draft(50, 25, 0.1, 50, 1.2, 0.5, 0.1, limit_inputs=False)
+    assert not np.isnan(result.ppd_ad)
+
+
+def test_ankle_draft_limit_inputs_false_skips_valueerror() -> None:
+    """limit_inputs=False bypasses the vr < 0.2 equation-applicability check."""
+    # vr=0.5 normally raises ValueError; with limit_inputs=False it should not
+    result = ankle_draft(25, 25, 0.5, 50, 1.2, 0.5, 0.1, limit_inputs=False)
+    assert not np.isnan(result.ppd_ad)
+
+
+def test_ankle_draft_limit_inputs_true_still_warns_and_nans() -> None:
+    """limit_inputs=True (default) keeps current behavior: warning + NaN mask."""
+    with pytest.warns(UserWarning):
+        result = ankle_draft(50, 25, 0.1, 50, 1.2, 0.5, 0.1)
+    assert np.isnan(result.ppd_ad)

--- a/tests/test_heat_index_rothfusz.py
+++ b/tests/test_heat_index_rothfusz.py
@@ -40,7 +40,7 @@ def test_below_threshold_produces_nan() -> None:
 
 def test_below_threshold_warns_scalar() -> None:
     """Scalar tdb below 27°C triggers a UserWarning with the specific value."""
-    with pytest.warns(UserWarning, match=r"Value of 'tdb' \(25\.0\).*\[27\.0, inf\]"):
+    with pytest.warns(UserWarning, match=r"'tdb' has value 25\.0.*\[27\.0, inf\]"):
         heat_index_rothfusz(tdb=25, rh=80)
 
 

--- a/tests/test_heat_index_rothfusz.py
+++ b/tests/test_heat_index_rothfusz.py
@@ -32,16 +32,39 @@ def test_single_input_caution() -> None:
 
 def test_below_threshold_produces_nan() -> None:
     """Test that the function returns NaN for heat index below threshold."""
-    result = heat_index_rothfusz(tdb=25, rh=80)
+    with pytest.warns(UserWarning):
+        result = heat_index_rothfusz(tdb=25, rh=80)
     assert np.isnan(result.hi).item()
     assert np.isnan(result.stress_category)
+
+
+def test_below_threshold_warns_scalar() -> None:
+    """Scalar tdb below 27°C triggers a UserWarning with the specific value."""
+    with pytest.warns(UserWarning, match=r"Value of 'tdb' \(25\.0\).*\[27\.0, inf\]"):
+        heat_index_rothfusz(tdb=25, rh=80)
+
+
+def test_below_threshold_warns_array() -> None:
+    """Array with tdb below 27°C triggers a UserWarning with indices and values."""
+    with pytest.warns(UserWarning, match=r"'tdb'.*\[20\.0\].*\[1\]"):
+        result = heat_index_rothfusz(tdb=[30.0, 20.0, 28.5], rh=[70.0, 90.0, 50.0])
+    assert np.isnan(result.hi[1])
+    assert np.isfinite(result.hi[0]) and np.isfinite(result.hi[2])
+
+
+def test_limit_inputs_false_no_warning(recwarn) -> None:
+    """With limit_inputs=False, no UserWarning is raised for out-of-range tdb."""
+    result = heat_index_rothfusz(tdb=25, rh=80, limit_inputs=False)
+    assert len(recwarn) == 0
+    assert np.isfinite(result.hi)
 
 
 def test_vector_input_no_rounding() -> None:
     """Test that the function handles vector inputs correctly without rounding."""
     tdb = [30.0, 20.0, 28.5]
     rh = [70.0, 90.0, 50.0]
-    result = heat_index_rothfusz(tdb=tdb, rh=rh, round_output=False)
+    with pytest.warns(UserWarning):
+        result = heat_index_rothfusz(tdb=tdb, rh=rh, round_output=False)
     hi = result.hi
     # Shape matches inputs
     assert hi.shape == (3,)

--- a/tests/test_pmv_ppd_ashrae.py
+++ b/tests/test_pmv_ppd_ashrae.py
@@ -179,3 +179,78 @@ class TestPmvPpd:
         """Test that the function raises a ValueError for an unsupported model."""
         with pytest.raises(ValueError):
             pmv_ppd_ashrae(25, 25, 0.1, 50, 1.1, 0.5, model="random")
+
+    def test_out_of_range_warns(self) -> None:
+        """Inputs outside ASHRAE 55 limits trigger a UserWarning naming the parameter."""
+        with pytest.warns(UserWarning, match=r"'tdb'"):
+            result = pmv_ppd_ashrae(
+                tdb=41,
+                tr=25,
+                vr=0.1,
+                rh=50,
+                met=1.1,
+                clo=0.5,
+                model=Models.ashrae_55_2023.value,
+            )
+        assert np.isnan(result.pmv)
+
+    def test_limit_inputs_false_no_warning(self, recwarn) -> None:
+        """With limit_inputs=False, no UserWarning is raised for out-of-range inputs."""
+        pmv_ppd_ashrae(
+            tdb=41,
+            tr=41,
+            vr=2,
+            rh=50,
+            met=0.7,
+            clo=2.1,
+            model=Models.ashrae_55_2023.value,
+            limit_inputs=False,
+        )
+        assert len(recwarn) == 0
+
+    def test_airspeed_control_false_cond1_warns(self) -> None:
+        """airspeed_control=False: v > 0.8 with low clo and met triggers UserWarning."""
+        # to ≈ 26 > 25.5, so only cond1 applies: v=0.9 > 0.8, clo=0.5 < 0.7, met=1.1 < 1.3
+        with pytest.warns(
+            UserWarning, match=r"airspeed_control=False.*exceed 0\.8 m/s"
+        ):
+            pmv_ppd_ashrae(
+                tdb=26,
+                tr=26,
+                vr=0.9,
+                rh=50,
+                met=1.1,
+                clo=0.5,
+                model=Models.ashrae_55_2023.value,
+                airspeed_control=False,
+            )
+
+    def test_airspeed_control_false_cond2_warns(self) -> None:
+        """airspeed_control=False: v exceeds comfort-zone limit triggers UserWarning."""
+        # to ≈ 24, so 23 < to < 25.5; v=0.6 exceeds computed v_limit ≈ 0.32
+        with pytest.warns(UserWarning, match=r"airspeed_control=False.*comfort zone"):
+            pmv_ppd_ashrae(
+                tdb=24,
+                tr=24,
+                vr=0.6,
+                rh=50,
+                met=1.1,
+                clo=0.5,
+                model=Models.ashrae_55_2023.value,
+                airspeed_control=False,
+            )
+
+    def test_airspeed_control_false_cond3_warns(self) -> None:
+        """airspeed_control=False: v > 0.2 when to <= 23°C triggers UserWarning."""
+        # to ≈ 22 <= 23; v=0.3 > 0.2, clo=0.5 < 0.7, met=1.1 < 1.3
+        with pytest.warns(UserWarning, match=r"airspeed_control=False.*0\.2 m/s"):
+            pmv_ppd_ashrae(
+                tdb=22,
+                tr=22,
+                vr=0.3,
+                rh=50,
+                met=1.1,
+                clo=0.5,
+                model=Models.ashrae_55_2023.value,
+                airspeed_control=False,
+            )

--- a/tests/test_pmv_ppd_ashrae.py
+++ b/tests/test_pmv_ppd_ashrae.py
@@ -212,7 +212,7 @@ class TestPmvPpd:
         """airspeed_control=False: v > 0.8 with low clo and met triggers UserWarning."""
         # to ≈ 26 > 25.5, so only cond1 applies: v=0.9 > 0.8, clo=0.5 < 0.7, met=1.1 < 1.3
         with pytest.warns(
-            UserWarning, match=r"airspeed_control=False.*exceed 0\.8 m/s"
+            UserWarning, match=r"airspeed_control=False.*exceeding 0\.8 m/s"
         ):
             pmv_ppd_ashrae(
                 tdb=26,
@@ -243,7 +243,9 @@ class TestPmvPpd:
     def test_airspeed_control_false_cond3_warns(self) -> None:
         """airspeed_control=False: v > 0.2 when to <= 23°C triggers UserWarning."""
         # to ≈ 22 <= 23; v=0.3 > 0.2, clo=0.5 < 0.7, met=1.1 < 1.3
-        with pytest.warns(UserWarning, match=r"airspeed_control=False.*0\.2 m/s"):
+        with pytest.warns(
+            UserWarning, match=r"airspeed_control=False.*exceeding 0\.2 m/s"
+        ):
             pmv_ppd_ashrae(
                 tdb=22,
                 tr=22,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,7 +4,7 @@ import pytest
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
     Units,
-    _check_standard_compliance_array,
+    _check_ashrae55_compliance,
     body_surface_area,
     clo_area_factor,
     clo_correction_factor_environment,
@@ -370,15 +370,16 @@ class TestValidRange:
     def test_scalar_out_of_range_warns(self) -> None:
         """Scalar value outside range triggers UserWarning with the value."""
         with pytest.warns(
-            UserWarning, match=r"Value of 'tdb' \(50\.0\).*\[10\.0, 40\.0\]"
+            UserWarning, match=r"'tdb' has value 50\.0.*\[10\.0, 40\.0\]"
         ):
             result = valid_range(50.0, (10.0, 40.0), "tdb")
         assert np.isnan(result)
 
     def test_array_out_of_range_warns(self) -> None:
-        """Array with out-of-range values triggers UserWarning with indices and values."""
+        """Array with out-of-range values triggers UserWarning with count, values, and indices."""
         with pytest.warns(
-            UserWarning, match=r"'tdb'.*\[10\.0, 40\.0\].*\[50\.0, 45\.0\].*\[1, 3\]"
+            UserWarning,
+            match=r"'tdb' has 2 values \[50\.0, 45\.0\] at indices \[1, 3\].*\[10\.0, 40\.0\]",
         ):
             result = valid_range([20.0, 50.0, 30.0, 45.0], (10.0, 40.0), "tdb")
         assert np.isnan(result[1]) and np.isnan(result[3])
@@ -390,24 +391,34 @@ class TestValidRange:
         assert len(recwarn) == 0
         assert result == 25.0
 
-    def test_no_param_name_no_warning(self, recwarn) -> None:
-        """Without param_name, no warning is issued even for out-of-range values."""
-        result = valid_range(50.0, (10.0, 40.0))
-        assert len(recwarn) == 0
+    def test_no_param_name_auto_extracts_from_caller(self) -> None:
+        """Without ``param_name``, the caller's variable name is auto-extracted."""
+        tdb = 50.0
+        with pytest.warns(
+            UserWarning, match=r"'tdb' has value 50\.0.*\[10\.0, 40\.0\]"
+        ):
+            result = valid_range(tdb, (10.0, 40.0))
+        assert np.isnan(result)
+
+    def test_no_param_name_literal_falls_back_to_unknown(self) -> None:
+        """Literal first arg cannot be auto-named; warning falls back to ``<unknown>``."""
+        with pytest.warns(
+            UserWarning, match=r"'<unknown>' has value 50\.0.*\[10\.0, 40\.0\]"
+        ):
+            result = valid_range(50.0, (10.0, 40.0))
         assert np.isnan(result)
 
 
-class TestCheckStandardComplianceArray:
-    """Tests for _check_standard_compliance_array warning behaviour (airspeed_control=False)."""
+class TestCheckAshrae55Compliance:
+    """Tests for _check_ashrae55_compliance warning behaviour (airspeed_control=False)."""
 
     def test_airspeed_control_cond1_warns(self) -> None:
         """cond1: v > 0.8 with clo < 0.7 and met < 1.3 triggers UserWarning.
 
         tdb=tr=30 → to=30 > 25.5, so cond2 does not trigger alongside cond1.
         """
-        with pytest.warns(UserWarning, match=r"exceed 0.8 m/s") as record:
-            _check_standard_compliance_array(
-                "55-2023",
+        with pytest.warns(UserWarning, match=r"exceeding 0\.8 m/s") as record:
+            _check_ashrae55_compliance(
                 tdb=np.float64(30),
                 tr=np.float64(30),
                 v=np.float64(1.0),
@@ -423,8 +434,7 @@ class TestCheckStandardComplianceArray:
         With tdb=tr=24, to=24; v_limit ≈ 0.32; v=0.5 > v_limit triggers cond2.
         """
         with pytest.warns(UserWarning, match=r"comfort zone"):
-            _check_standard_compliance_array(
-                "55-2023",
+            _check_ashrae55_compliance(
                 tdb=np.float64(24),
                 tr=np.float64(24),
                 v=np.float64(0.5),
@@ -439,8 +449,7 @@ class TestCheckStandardComplianceArray:
         With tdb=tr=22, to=22 <= 23; v=0.3 > 0.2 triggers cond3.
         """
         with pytest.warns(UserWarning, match=r"operative temperature is ≤ 23°C"):
-            _check_standard_compliance_array(
-                "55-2023",
+            _check_ashrae55_compliance(
                 tdb=np.float64(22),
                 tr=np.float64(22),
                 v=np.float64(0.3),
@@ -451,8 +460,7 @@ class TestCheckStandardComplianceArray:
 
     def test_airspeed_control_true_no_condition_warning(self, recwarn) -> None:
         """airspeed_control=True skips cond1/cond2/cond3 checks even when v=1.0."""
-        _check_standard_compliance_array(
-            "55-2023",
+        _check_ashrae55_compliance(
             tdb=np.float64(25),
             tr=np.float64(25),
             v=np.float64(1.0),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
 
+from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
     Units,
+    _check_standard_compliance_array,
     body_surface_area,
     clo_area_factor,
     clo_correction_factor_environment,
@@ -360,6 +362,105 @@ def test_v_relative() -> None:
     met = 1.5
     expected_result = -1.5 + 0.3 * 0.5
     assert np.allclose(v_relative(v, met), expected_result, atol=1e-6)
+
+
+class TestValidRange:
+    """Tests for valid_range warning behaviour."""
+
+    def test_scalar_out_of_range_warns(self) -> None:
+        """Scalar value outside range triggers UserWarning with the value."""
+        with pytest.warns(
+            UserWarning, match=r"Value of 'tdb' \(50\.0\).*\[10\.0, 40\.0\]"
+        ):
+            result = valid_range(50.0, (10.0, 40.0), "tdb")
+        assert np.isnan(result)
+
+    def test_array_out_of_range_warns(self) -> None:
+        """Array with out-of-range values triggers UserWarning with indices and values."""
+        with pytest.warns(
+            UserWarning, match=r"'tdb'.*\[10\.0, 40\.0\].*\[50\.0, 45\.0\].*\[1, 3\]"
+        ):
+            result = valid_range([20.0, 50.0, 30.0, 45.0], (10.0, 40.0), "tdb")
+        assert np.isnan(result[1]) and np.isnan(result[3])
+        assert result[0] == 20.0 and result[2] == 30.0
+
+    def test_in_range_no_warning(self, recwarn) -> None:
+        """Values within range produce no warning."""
+        result = valid_range(25.0, (10.0, 40.0), "tdb")
+        assert len(recwarn) == 0
+        assert result == 25.0
+
+    def test_no_param_name_no_warning(self, recwarn) -> None:
+        """Without param_name, no warning is issued even for out-of-range values."""
+        result = valid_range(50.0, (10.0, 40.0))
+        assert len(recwarn) == 0
+        assert np.isnan(result)
+
+
+class TestCheckStandardComplianceArray:
+    """Tests for _check_standard_compliance_array warning behaviour (airspeed_control=False)."""
+
+    def test_airspeed_control_cond1_warns(self) -> None:
+        """cond1: v > 0.8 with clo < 0.7 and met < 1.3 triggers UserWarning.
+
+        tdb=tr=30 → to=30 > 25.5, so cond2 does not trigger alongside cond1.
+        """
+        with pytest.warns(UserWarning, match=r"exceed 0.8 m/s") as record:
+            _check_standard_compliance_array(
+                "55-2023",
+                tdb=np.float64(30),
+                tr=np.float64(30),
+                v=np.float64(1.0),
+                met=np.float64(1.2),
+                clo=np.float64(0.5),
+                airspeed_control=False,
+            )
+        assert len(record) == 1
+
+    def test_airspeed_control_cond2_warns(self) -> None:
+        """cond2: v exceeds ASHRAE comfort-zone limit (23°C < to < 25.5°C) triggers UserWarning.
+
+        With tdb=tr=24, to=24; v_limit ≈ 0.32; v=0.5 > v_limit triggers cond2.
+        """
+        with pytest.warns(UserWarning, match=r"comfort zone"):
+            _check_standard_compliance_array(
+                "55-2023",
+                tdb=np.float64(24),
+                tr=np.float64(24),
+                v=np.float64(0.5),
+                met=np.float64(1.2),
+                clo=np.float64(0.5),
+                airspeed_control=False,
+            )
+
+    def test_airspeed_control_cond3_warns(self) -> None:
+        """cond3: v > 0.2 when to <= 23°C triggers UserWarning.
+
+        With tdb=tr=22, to=22 <= 23; v=0.3 > 0.2 triggers cond3.
+        """
+        with pytest.warns(UserWarning, match=r"operative temperature is ≤ 23°C"):
+            _check_standard_compliance_array(
+                "55-2023",
+                tdb=np.float64(22),
+                tr=np.float64(22),
+                v=np.float64(0.3),
+                met=np.float64(1.2),
+                clo=np.float64(0.5),
+                airspeed_control=False,
+            )
+
+    def test_airspeed_control_true_no_condition_warning(self, recwarn) -> None:
+        """airspeed_control=True skips cond1/cond2/cond3 checks even when v=1.0."""
+        _check_standard_compliance_array(
+            "55-2023",
+            tdb=np.float64(25),
+            tr=np.float64(25),
+            v=np.float64(1.0),
+            met=np.float64(1.2),
+            clo=np.float64(0.5),
+            airspeed_control=True,
+        )
+        assert len(recwarn) == 0
 
 
 def test_validate_type() -> None:

--- a/tests/test_vertical_tmp_grad_ppd.py
+++ b/tests/test_vertical_tmp_grad_ppd.py
@@ -1,4 +1,7 @@
+import warnings
+
 import numpy as np
+import pytest
 
 from pythermalcomfort.models.vertical_tmp_grad_ppd import vertical_tmp_grad_ppd
 from tests.conftest import Urls, retrieve_reference_table, validate_result
@@ -26,3 +29,27 @@ def test_vertical_tmp_grad_ppd(get_test_url, retrieve_data) -> None:
         np.nan,
         equal_nan=True,
     )
+
+
+def test_vertical_tmp_grad_ppd_limit_inputs_false_suppresses_warning_and_nan() -> None:
+    """limit_inputs=False bypasses range checks: no UserWarning, no NaN mask."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = vertical_tmp_grad_ppd(
+            50,
+            25,
+            0.1,
+            50,
+            1.2,
+            0.5,
+            7,
+            limit_inputs=False,
+        )
+    assert not np.isnan(result.ppd_vg)
+
+
+def test_vertical_tmp_grad_ppd_limit_inputs_true_still_warns_and_nans() -> None:
+    """limit_inputs=True (default) keeps current behavior: warning + NaN mask."""
+    with pytest.warns(UserWarning):
+        result = vertical_tmp_grad_ppd(50, 25, 0.1, 50, 1.2, 0.5, 7)
+    assert np.isnan(result.ppd_vg)


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the thermal comfort models, enhances the release and CI workflow, and updates documentation to clarify the release process. The most important changes are grouped below.

**Model enhancements and bug fixes:**

* Added an optional `round_output` parameter to the `adaptive_ashrae` and `adaptive_en` functions and their input classes, allowing users to control whether output values are rounded for reporting consistency. [[1]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R23) [[2]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R60-R67) [[3]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R151) [[4]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR18) [[5]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR50-R54) [[6]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR151-R170) [[7]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R216-R224) [[8]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R237-R245)
* Introduced a `limit_inputs` parameter to the `ankle_draft` and `vertical_tmp_grad_ppd` models and their input classes, consistent with other model functions. These models now raise a `UserWarning` when inputs exceed applicability limits. [[1]](diffhunk://#diff-1b4b23c7963fe9d88a35bfa73a64fcf0b81c073d4a06b50dc369357be04af7d1R25) [[2]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R261) [[3]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R273) [[4]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R976) [[5]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R988)
* Fixed the `compliance` attribute being included in non-ASHRAE PMV model outputs; it is now only returned by `pmv_ppd_ashrae`. (No explicit diff shown, but referenced in changelog [CHANGELOG.rstR4-R23](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR4-R23))
* Fixed UTCI stress category mapping when `units="IP"`; categories are now mapped before unit conversion. (No explicit diff shown, but referenced in changelog [CHANGELOG.rstR4-R23](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR4-R23))

**Release and CI workflow improvements:**

* Updated the release process documentation in `README.rst` to clarify the standard release cycle, tagging rules, and the use of GitHub Actions Trusted Publishing (OIDC).
* Improved the GitHub Actions workflows:
  - Refined triggers and job dependencies for formatting and testing, removed redundant steps, and clarified which branches trigger jobs. [[1]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L14-R26) [[2]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L63-R42) [[3]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L87-R66) [[4]](diffhunk://#diff-eb9ae47cbd14fc8f82fa1280f41ef6b02f7e2e55165025ccad169dba48e750c9L54-L63) [[5]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R8) [[6]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L52-L56)
  - Ensured that deploy jobs for TestPyPI and PyPI are triggered correctly by tag patterns and branch rules. [[1]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L63-R42) [[2]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL169-R230)

**Documentation and changelog:**

* Added detailed entries to `CHANGELOG.rst` for versions 3.9.8 and 3.9.3, summarizing new features, fixes, and maintenance updates.

---

**References:**  
[[1]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R23) [[2]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R60-R67) [[3]](diffhunk://#diff-cbe50c27566d940ad1ab1d187c37bcfaa011e10179ed90560bc15ddd99aa4ac2R151) [[4]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR18) [[5]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR50-R54) [[6]](diffhunk://#diff-594e56538b9046872b53b4ecd932fc7b1062431dd4b588d1e83bfb40a4a4700fR151-R170) [[7]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R216-R224) [[8]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R237-R245) [[9]](diffhunk://#diff-1b4b23c7963fe9d88a35bfa73a64fcf0b81c073d4a06b50dc369357be04af7d1R25) [[10]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R261) [[11]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R273) [[12]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R976) [[13]](diffhunk://#diff-2038b315e6fed595a255ee79e4cc55ed278571901285cffd7449659eeb1ae2e5R988) [[14]](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR4-R23) [[15]](diffhunk://#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL169-R230) [[16]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L14-R26) [[17]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L63-R42) [[18]](diffhunk://#diff-ee362126f85617c12cb7f17c4b740969d1fc26df49ab6cdd58bb2a4e36555ba7L87-R66) [[19]](diffhunk://#diff-eb9ae47cbd14fc8f82fa1280f41ef6b02f7e2e55165025ccad169dba48e750c9L54-L63) [[20]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R8) [[21]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L52-L56)