### PR TITLE
refactor: use NumericInput alias across pythermalcomfort (#325)

### DIFF
--- a/pythermalcomfort/classes_input.py
+++ b/pythermalcomfort/classes_input.py
@@ -10,9 +10,8 @@ if TYPE_CHECKING:
 
 import numpy as np
 
-from pythermalcomfort.utilities import Postures, Sex, Units, validate_type
+from pythermalcomfort.utilities import NumericInput, Postures, Sex, Units, validate_type
 
-NumericInput = float | int | np.ndarray | list
 _NUMERIC_TYPES = NumericInput.__args__
 
 

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import datetime as dt
 import textwrap
 from dataclasses import dataclass, fields, is_dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 from numpy._typing import NDArray
+
+if TYPE_CHECKING:
+    # Use TYPE_CHECKING to avoid circular import: utilities (where
+    # NumericInput is defined) imports PsychrometricValues from this module.
+    from pythermalcomfort.utilities import NumericInput
 
 
 class AutoStrMixin:
@@ -99,7 +105,7 @@ class APMV(AutoStrMixin):
         Predicted Mean Vote.
     """
 
-    a_pmv: float | list[float]
+    a_pmv: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -125,11 +131,11 @@ class AdaptiveASHRAE(AutoStrMixin):
         Acceptability for 90% occupants.
     """
 
-    tmp_cmf: float | list[float]
-    tmp_cmf_80_low: float | list[float]
-    tmp_cmf_80_up: float | list[float]
-    tmp_cmf_90_low: float | list[float]
-    tmp_cmf_90_up: float | list[float]
+    tmp_cmf: NumericInput
+    tmp_cmf_80_low: NumericInput
+    tmp_cmf_80_up: NumericInput
+    tmp_cmf_90_low: NumericInput
+    tmp_cmf_90_up: NumericInput
     acceptability_80: bool | list[bool]
     acceptability_90: bool | list[bool]
 
@@ -163,16 +169,16 @@ class AdaptiveEN(AutoStrMixin):
         Lower acceptable comfort temperature for category III, default in [°C] or in [°F].
     """
 
-    tmp_cmf: float | list[float]
+    tmp_cmf: NumericInput
     acceptability_cat_i: bool | list[bool]
     acceptability_cat_ii: bool | list[bool]
     acceptability_cat_iii: bool | list[bool]
-    tmp_cmf_cat_i_up: float | list[float]
-    tmp_cmf_cat_ii_up: float | list[float]
-    tmp_cmf_cat_iii_up: float | list[float]
-    tmp_cmf_cat_i_low: float | list[float]
-    tmp_cmf_cat_ii_low: float | list[float]
-    tmp_cmf_cat_iii_low: float | list[float]
+    tmp_cmf_cat_i_up: NumericInput
+    tmp_cmf_cat_ii_up: NumericInput
+    tmp_cmf_cat_iii_up: NumericInput
+    tmp_cmf_cat_i_low: NumericInput
+    tmp_cmf_cat_ii_low: NumericInput
+    tmp_cmf_cat_iii_low: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -187,7 +193,7 @@ class AnkleDraft(AutoStrMixin):
         Indicates if the air speed at the ankle level is acceptable according to ASHRAE 55 2020 standard.
     """
 
-    ppd_ad: float | list[float]
+    ppd_ad: NumericInput
     acceptability: bool | list[bool]
 
 
@@ -215,7 +221,7 @@ class ATHB(AutoStrMixin):
         Predicted Mean Vote calculated with the Adaptive Thermal Heat Balance framework.
     """
 
-    athb_pmv: float | list[float]
+    athb_pmv: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -229,7 +235,7 @@ class CloTOut(AutoStrMixin):
         Representative clothing insulation Icl.
     """
 
-    clo_tout: float | list[float]
+    clo_tout: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -242,7 +248,7 @@ class CE(AutoStrMixin):
         Cooling Effect value.
     """
 
-    ce: float | list[float]
+    ce: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -257,7 +263,7 @@ class DI(AutoStrMixin):
         Classification of the thermal comfort conditions according to the discomfort index.
     """
 
-    di: float | list[float]
+    di: NumericInput
     discomfort_condition: str | list[str]
 
 
@@ -272,7 +278,7 @@ class EPMV(AutoStrMixin):
         Adjusted Predicted Mean Votes with Expectancy Factor.
     """
 
-    e_pmv: float | list[float]
+    e_pmv: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -285,7 +291,7 @@ class ESI(AutoStrMixin):
         Environmental Stress Index.
     """
 
-    esi: float | list[float]
+    esi: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -314,7 +320,7 @@ class Humidex(AutoStrMixin):
         Degree of comfort or discomfort as defined in Havenith and Fiala (2016).
     """
 
-    humidex: float | list[float]
+    humidex: NumericInput
     discomfort: str | list[str]
 
 
@@ -328,7 +334,7 @@ class NET(AutoStrMixin):
         Normal Effective Temperature, [°C].
     """
 
-    net: float | list[float]
+    net: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -341,7 +347,7 @@ class PETSteady(AutoStrMixin):
         Physiological Equivalent Temperature.
     """
 
-    pet: float | list[float]
+    pet: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -380,17 +386,17 @@ class PHS(AutoStrMixin):
         at each 1 minute step. Intended for chaining simulation segments.
     """
 
-    t_re: float | list[float]
-    t_sk: float | list[float]
-    t_cr: float | list[float]
-    t_cr_eq: float | list[float]
-    t_sk_t_cr_wg: float | list[float]
-    d_lim_loss_50: float | list[float]
-    d_lim_loss_95: float | list[float]
-    d_lim_t_re: float | list[float]
-    sweat_loss_g: float | list[float]
-    sweat_rate_watt: float | list[float]
-    evap_load_wm2_min: float | list[float]
+    t_re: NumericInput
+    t_sk: NumericInput
+    t_cr: NumericInput
+    t_cr_eq: NumericInput
+    t_sk_t_cr_wg: NumericInput
+    d_lim_loss_50: NumericInput
+    d_lim_loss_95: NumericInput
+    d_lim_t_re: NumericInput
+    sweat_loss_g: NumericInput
+    sweat_rate_watt: NumericInput
+    evap_load_wm2_min: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -403,7 +409,7 @@ class PMV(AutoStrMixin):
         Predicted Mean Vote.
     """
 
-    pmv: float | list[float]
+    pmv: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -421,9 +427,9 @@ class PMVPPD(AutoStrMixin):
         Predicted thermal sensation vote.
     """
 
-    pmv: float | list[float]
-    ppd: float | list[float]
-    tsv: float | list[float]
+    pmv: NumericInput
+    ppd: NumericInput
+    tsv: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -468,7 +474,7 @@ class SET(AutoStrMixin):
         Standard effective temperature, [°C].
     """
 
-    set: float | list[float]
+    set: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -484,8 +490,8 @@ class SolarGain(AutoStrMixin):
         temperature of the space should be increased if no solar radiation is present.
     """
 
-    erf: float | list[float]
-    delta_mrt: float | list[float]
+    erf: NumericInput
+    delta_mrt: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -533,24 +539,24 @@ class GaggeTwoNodes(AutoStrMixin):
         Predicted Thermal Sensation.
     """
 
-    e_skin: float | list[float]
-    e_rsw: float | list[float]
-    e_max: float | list[float]
-    q_sensible: float | list[float]
-    q_skin: float | list[float]
-    q_res: float | list[float]
-    t_core: float | list[float]
-    t_skin: float | list[float]
-    m_bl: float | list[float]
-    m_rsw: float | list[float]
-    w: float | list[float]
-    w_max: float | list[float]
-    set: float | list[float]
-    et: float | list[float]
-    pmv_gagge: float | list[float]
-    pmv_set: float | list[float]
-    disc: float | list[float]
-    t_sens: float | list[float]
+    e_skin: NumericInput
+    e_rsw: NumericInput
+    e_max: NumericInput
+    q_sensible: NumericInput
+    q_skin: NumericInput
+    q_res: NumericInput
+    t_core: NumericInput
+    t_skin: NumericInput
+    m_bl: NumericInput
+    m_rsw: NumericInput
+    w: NumericInput
+    w_max: NumericInput
+    set: NumericInput
+    et: NumericInput
+    pmv_gagge: NumericInput
+    pmv_set: NumericInput
+    disc: NumericInput
+    t_sens: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -565,8 +571,8 @@ class GaggeTwoNodesJi(AutoStrMixin):
         Skin temperature, [°C].
     """
 
-    t_core: float | list[float]
-    t_skin: float | list[float]
+    t_core: NumericInput
+    t_skin: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -579,7 +585,7 @@ class THI(AutoStrMixin):
         Temperature-Humidity Index (THI).
     """
 
-    thi: float | list[float]
+    thi: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -610,16 +616,16 @@ class GaggeTwoNodesSleep(AutoStrMixin):
         Skin-blood-flow rate per unit surface area, [kg/h/m2].
     """
 
-    set: float | list[float]
-    t_core: float | list[float]
-    t_skin: float | list[float]
-    wet: float | list[float]
-    t_sens: float | list[float]
-    disc: float | list[float]
-    e_skin: float | list[float]
-    met_shivering: float | list[float]
-    alfa: float | list[float]
-    skin_blood_flow: float | list[float]
+    set: NumericInput
+    t_core: NumericInput
+    t_skin: NumericInput
+    wet: NumericInput
+    t_sens: NumericInput
+    disc: NumericInput
+    e_skin: NumericInput
+    met_shivering: NumericInput
+    alfa: NumericInput
+    skin_blood_flow: NumericInput
 
 
 @dataclass(frozen=True)
@@ -662,18 +668,18 @@ class UseFansHeatwaves(AutoStrMixin):
         True if heat strain is caused by regulatory sweating (m_rsw) reaching its maximum value.
     """
 
-    e_skin: float | list[float]
-    e_rsw: float | list[float]
-    e_max: float | list[float]
-    q_sensible: float | list[float]
-    q_skin: float | list[float]
-    q_res: float | list[float]
-    t_core: float | list[float]
-    t_skin: float | list[float]
-    m_bl: float | list[float]
-    m_rsw: float | list[float]
-    w: float | list[float]
-    w_max: float | list[float]
+    e_skin: NumericInput
+    e_rsw: NumericInput
+    e_max: NumericInput
+    q_sensible: NumericInput
+    q_skin: NumericInput
+    q_res: NumericInput
+    t_core: NumericInput
+    t_skin: NumericInput
+    m_bl: NumericInput
+    m_rsw: NumericInput
+    w: NumericInput
+    w_max: NumericInput
     heat_strain: bool | list[bool]
     heat_strain_blood_flow: bool | list[bool]
     heat_strain_w: bool | list[bool]
@@ -692,7 +698,7 @@ class UTCI(AutoStrMixin):
         UTCI categorized in terms of thermal stress [Blazejczyk2013]_.
     """
 
-    utci: float | list[float]
+    utci: NumericInput
     stress_category: str | list[str]
 
 
@@ -709,7 +715,7 @@ class VerticalTGradPPD(AutoStrMixin):
         True if the value of air speed at the ankle level is acceptable (PPD_vg <= 5%).
     """
 
-    ppd_vg: float | list[float]
+    ppd_vg: NumericInput
     acceptability: bool | list[bool]
 
 
@@ -723,7 +729,7 @@ class WBGT(AutoStrMixin):
         Wet Bulb Globe Temperature Index.
     """
 
-    wbgt: float | list[float]
+    wbgt: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -736,7 +742,7 @@ class WCI(AutoStrMixin):
         Wind Chill Index, [W/m^2].
     """
 
-    wci: float | list[float]
+    wci: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -749,7 +755,7 @@ class WCT(AutoStrMixin):
         Wind Chill Temperature, [°C].
     """
 
-    wct: float | list[float]
+    wct: NumericInput
 
 
 @dataclass(frozen=True)
@@ -762,7 +768,7 @@ class WorkCapacity(AutoStrMixin):
         Work capacity affected by heat.
     """
 
-    capacity: float | list[float]
+    capacity: NumericInput
 
 
 @dataclass(frozen=True, repr=False)
@@ -1083,8 +1089,8 @@ class SportsHeatStressRisk(AutoStrMixin):
         Heat stress management recommendations for the calculated risk level.
     """
 
-    risk_level_interpolated: float | list[float]
-    t_medium: float | list[float]
-    t_high: float | list[float]
-    t_extreme: float | list[float]
+    risk_level_interpolated: NumericInput
+    t_medium: NumericInput
+    t_high: NumericInput
+    t_extreme: NumericInput
     recommendation: str | list[str]

--- a/pythermalcomfort/models/adaptive_ashrae.py
+++ b/pythermalcomfort/models/adaptive_ashrae.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ASHRAEInputs
+from pythermalcomfort.classes_input import ASHRAEInputs, NumericInput
 from pythermalcomfort.classes_return import AdaptiveASHRAE
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
@@ -14,10 +14,10 @@ from pythermalcomfort.utilities import (
 
 
 def adaptive_ashrae(
-    tdb: float | list[float],
-    tr: float | list[float],
-    t_running_mean: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    t_running_mean: NumericInput,
+    v: NumericInput,
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
     round_output: bool = True,

--- a/pythermalcomfort/models/adaptive_en.py
+++ b/pythermalcomfort/models/adaptive_en.py
@@ -2,17 +2,17 @@ from typing import Literal
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ENInputs
+from pythermalcomfort.classes_input import ENInputs, NumericInput
 from pythermalcomfort.classes_return import AdaptiveEN
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import Units, operative_tmp, units_converter
 
 
 def adaptive_en(
-    tdb: float | list[float],
-    tr: float | list[float],
-    t_running_mean: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    t_running_mean: NumericInput,
+    v: NumericInput,
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
     round_output: bool = True,

--- a/pythermalcomfort/models/ankle_draft.py
+++ b/pythermalcomfort/models/ankle_draft.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import AnkleDraftInputs
+from pythermalcomfort.classes_input import AnkleDraftInputs, NumericInput
 from pythermalcomfort.classes_return import AnkleDraft
 from pythermalcomfort.models.pmv_ppd_ashrae import pmv_ppd_ashrae
 from pythermalcomfort.utilities import (
@@ -14,13 +14,13 @@ from pythermalcomfort.utilities import (
 
 
 def ankle_draft(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    v_ankle: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    v_ankle: NumericInput,
     units: str = Units.SI.value,
     limit_inputs: bool = True,
 ) -> AnkleDraft:

--- a/pythermalcomfort/models/at.py
+++ b/pythermalcomfort/models/at.py
@@ -2,20 +2,21 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ATInputs
+from pythermalcomfort.classes_input import ATInputs, NumericInput
 from pythermalcomfort.classes_return import AT
 from pythermalcomfort.utilities import psy_ta_rh
 
 
 def at(
-    tdb: float | list[float],
-    rh: float | list[float],
-    v: float | list[float],
-    q: float | list[float] = None,
+    tdb: NumericInput,
+    rh: NumericInput,
+    v: NumericInput,
+    q: NumericInput = None,
     round_output: bool = True,
 ) -> AT:
-    """Calculate the Apparent Temperature (AT). The AT is defined as the temperature at
-    the reference humidity level producing the same amount of discomfort as that
+    """Calculate the Apparent Temperature (AT).
+
+    The AT is defined as the temperature at the reference humidity level producing the same amount of discomfort as that
     experienced under the current ambient temperature, humidity, and solar radiation
     [Steadman1984]_. In other words, the AT is an adjustment to the dry bulb temperature
     based on the relative humidity value. Absolute humidity with a dew point of 14°C is

--- a/pythermalcomfort/models/clo_tout.py
+++ b/pythermalcomfort/models/clo_tout.py
@@ -4,13 +4,13 @@ from typing import Literal
 
 import numpy as np
 
-from pythermalcomfort.classes_input import CloTOutInputs
+from pythermalcomfort.classes_input import CloTOutInputs, NumericInput
 from pythermalcomfort.classes_return import CloTOut
 from pythermalcomfort.utilities import Units, units_converter
 
 
 def clo_tout(
-    tout: float | list[float],
+    tout: NumericInput,
     units: Literal["SI", "IP"] = Units.SI.value,
 ) -> CloTOut:
     """Calculate representative clothing insulation Icl based on outdoor air temperature

--- a/pythermalcomfort/models/cooling_effect.py
+++ b/pythermalcomfort/models/cooling_effect.py
@@ -6,20 +6,20 @@ from typing import Literal
 import numpy as np
 from scipy import optimize
 
-from pythermalcomfort.classes_input import CEInputs
+from pythermalcomfort.classes_input import CEInputs, NumericInput
 from pythermalcomfort.classes_return import CE
 from pythermalcomfort.models.set_tmp import set_tmp
 from pythermalcomfort.utilities import Units, units_converter
 
 
 def cooling_effect(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0,
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0,
     units: Literal["SI", "IP"] = Units.SI.value,
 ) -> CE:
     """Return the value of the Cooling Effect (`CE`_) calculated in compliance with the

--- a/pythermalcomfort/models/discomfort_index.py
+++ b/pythermalcomfort/models/discomfort_index.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import DIInputs
+from pythermalcomfort.classes_input import DIInputs, NumericInput
 from pythermalcomfort.classes_return import DI
 from pythermalcomfort.shared_functions import mapping
 
 
 def discomfort_index(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
 ) -> DI:
     """Calculate the Discomfort Index (DI).
 

--- a/pythermalcomfort/models/esi.py
+++ b/pythermalcomfort/models/esi.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ESIInputs
+from pythermalcomfort.classes_input import ESIInputs, NumericInput
 from pythermalcomfort.classes_return import ESI
 
 
 def esi(
-    tdb: float | list[float],
-    rh: float | list[float],
-    sol_radiation_global: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
+    sol_radiation_global: NumericInput,
     round_output: bool = True,
 ) -> ESI:
     """Calculate the Environmental Stress Index (ESI) [Moran2001]_.

--- a/pythermalcomfort/models/heat_index_lu.py
+++ b/pythermalcomfort/models/heat_index_lu.py
@@ -4,13 +4,13 @@ import math
 
 import numpy as np
 
-from pythermalcomfort.classes_input import HIInputs
+from pythermalcomfort.classes_input import HIInputs, NumericInput
 from pythermalcomfort.classes_return import HI
 
 
 def heat_index_lu(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
     round_output: bool = True,
 ) -> HI:
     """Calculate the Heat Index (HI) in accordance with the Lu and Romps (2022) model

--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import HIInputs
+from pythermalcomfort.classes_input import HIInputs, NumericInput
 from pythermalcomfort.classes_return import HI
 from pythermalcomfort.shared_functions import mapping, valid_range
 
 
 def heat_index_rothfusz(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
     round_output: bool = True,
     limit_inputs: bool = True,
 ) -> HI:

--- a/pythermalcomfort/models/humidex.py
+++ b/pythermalcomfort/models/humidex.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import HumidexInputs, HumidexModels
+from pythermalcomfort.classes_input import HumidexInputs, HumidexModels, NumericInput
 from pythermalcomfort.classes_return import Humidex
 from pythermalcomfort.utilities import dew_point_tmp
 
 
 def humidex(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
     model: str = "rana",
     round_output: bool = True,
 ) -> Humidex:

--- a/pythermalcomfort/models/net.py
+++ b/pythermalcomfort/models/net.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import NETInputs
+from pythermalcomfort.classes_input import NETInputs, NumericInput
 from pythermalcomfort.classes_return import NET
 
 
 def net(
-    tdb: float | list[float],
-    rh: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
+    v: NumericInput,
     round_output: bool = True,
 ) -> NET:
     """Calculate the Normal Effective Temperature (NET). Missenard (1933)

--- a/pythermalcomfort/models/pet_steady.py
+++ b/pythermalcomfort/models/pet_steady.py
@@ -4,25 +4,25 @@ import numpy as np
 import numpy.typing as npt
 from scipy import optimize
 
-from pythermalcomfort.classes_input import PETSteadyInputs
+from pythermalcomfort.classes_input import NumericInput, PETSteadyInputs
 from pythermalcomfort.classes_return import PETSteady
 from pythermalcomfort.utilities import Postures, Sex, body_surface_area, p_sat
 
 
 def pet_steady(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    p_atm: float | list[float] = 1013.25,
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    p_atm: NumericInput = 1013.25,
     position: str | list[str] = Postures.sitting.value,
-    age: int | list[int] = 23,
-    sex: int | list[int] = Sex.male.value,
-    weight: float | list[float] = 75,
-    height: float | list[float] = 1.8,
-    wme: float | list[float] = 0,
+    age: NumericInput = 23,
+    sex: str | np.ndarray | list = Sex.male.value,
+    weight: NumericInput = 75,
+    height: NumericInput = 1.8,
+    wme: NumericInput = 0,
 ) -> PETSteady:
     """Calculate the steady physiological equivalent temperature (PET) using the Munich
     Energy-balance Model for Individuals (MEMI) to simulate the human body's thermal

--- a/pythermalcomfort/models/phs.py
+++ b/pythermalcomfort/models/phs.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 from numba import jit, prange
 
-from pythermalcomfort.classes_input import PHSInputs
+from pythermalcomfort.classes_input import NumericInput, PHSInputs
 from pythermalcomfort.classes_return import PHS
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import (
@@ -17,14 +17,14 @@ from pythermalcomfort.utilities import (
 
 
 def phs(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
     posture: str | list[str],
-    wme: float | np.ndarray | list[float] | list[int] = 0,
+    wme: NumericInput = 0,
     round_output: bool = True,
     model: str = Models.iso_7933_2023.value,
     **kwargs,

--- a/pythermalcomfort/models/pmv_a.py
+++ b/pythermalcomfort/models/pmv_a.py
@@ -4,21 +4,21 @@ from typing import Literal
 
 import numpy as np
 
-from pythermalcomfort.classes_input import APMVInputs
+from pythermalcomfort.classes_input import APMVInputs, NumericInput
 from pythermalcomfort.classes_return import APMV
 from pythermalcomfort.models.pmv_ppd_iso import pmv_ppd_iso
 from pythermalcomfort.utilities import Models, Units
 
 
 def pmv_a(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
     a_coefficient: float,
-    wme: float | list[float] = 0,
+    wme: NumericInput = 0,
     units: Literal["SI", "IP"] = Units.SI.value,
     limit_inputs: bool = True,
 ) -> APMV:

--- a/pythermalcomfort/models/pmv_athb.py
+++ b/pythermalcomfort/models/pmv_athb.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ATHBInputs
+from pythermalcomfort.classes_input import ATHBInputs, NumericInput
 from pythermalcomfort.classes_return import ATHB
 from pythermalcomfort.models._pmv_ppd_optimized import _pmv_ppd_optimized
 from pythermalcomfort.utilities import met_to_w_m2
 
 
 def pmv_athb(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    t_running_mean: float | list[float],
-    clo: bool | float | list[float] = False,
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    t_running_mean: NumericInput,
+    clo: bool | NumericInput = False,
 ) -> ATHB:
     """Return the PMV value calculated with the Adaptive Thermal Heat Balance Framework
     [Schweiker2022]_. The adaptive thermal heat balance (ATHB) framework introduced a

--- a/pythermalcomfort/models/pmv_e.py
+++ b/pythermalcomfort/models/pmv_e.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import EPMVInputs
+from pythermalcomfort.classes_input import EPMVInputs, NumericInput
 from pythermalcomfort.classes_return import EPMV
 from pythermalcomfort.models.pmv_ppd_iso import pmv_ppd_iso
 from pythermalcomfort.utilities import Models, Units
 
 
 def pmv_e(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    e_coefficient: float | list[float],
-    wme: float | list[float] = 0,
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    e_coefficient: NumericInput,
+    wme: NumericInput = 0,
     units: str = Units.SI.value,
     limit_inputs: bool = True,
 ) -> EPMV:

--- a/pythermalcomfort/models/pmv_ppd_ashrae.py
+++ b/pythermalcomfort/models/pmv_ppd_ashrae.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import PMVPPDInputs
+from pythermalcomfort.classes_input import NumericInput, PMVPPDInputs
 from pythermalcomfort.classes_return import PMVPPDAshrae
 from pythermalcomfort.models._pmv_ppd_optimized import _pmv_ppd_optimized
 from pythermalcomfort.models.cooling_effect import cooling_effect
@@ -16,13 +16,13 @@ from pythermalcomfort.utilities import (
 
 
 def pmv_ppd_ashrae(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0,
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0,
     model: str = Models.ashrae_55_2023.value,
     units: str = Units.SI.value,
     limit_inputs: bool = True,

--- a/pythermalcomfort/models/pmv_ppd_iso.py
+++ b/pythermalcomfort/models/pmv_ppd_iso.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import PMVPPDInputs
+from pythermalcomfort.classes_input import NumericInput, PMVPPDInputs
 from pythermalcomfort.classes_return import PMVPPD
 from pythermalcomfort.models._pmv_ppd_optimized import _pmv_ppd_optimized
 from pythermalcomfort.shared_functions import mapping, valid_range
@@ -14,13 +14,13 @@ from pythermalcomfort.utilities import (
 
 
 def pmv_ppd_iso(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0,
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0,
     model: str = Models.iso_7730_2005.value,
     units: str = Units.SI.value,
     limit_inputs: bool = True,

--- a/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
+++ b/pythermalcomfort/models/ridge_regression_predict_t_re_t_sk.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import RidgeRegressionInputs
+from pythermalcomfort.classes_input import NumericInput, RidgeRegressionInputs
 from pythermalcomfort.classes_return import PredictedBodyTemperatures
 from pythermalcomfort.shared_functions import valid_range
 from pythermalcomfort.utilities import Sex
@@ -192,14 +192,14 @@ def _check_ridge_regression_compliance(
 
 def ridge_regression_predict_t_re_t_sk(
     sex: Sex | str | list[Sex | str],
-    age: float | list[float],
-    height: float | list[float],
-    weight: float | list[float],
-    tdb: float | list[float],
-    rh: float | list[float],
+    age: NumericInput,
+    height: NumericInput,
+    weight: NumericInput,
+    tdb: NumericInput,
+    rh: NumericInput,
     duration: int,
-    t_re: float | list[float] | None = None,
-    t_sk: float | list[float] | None = None,
+    t_re: NumericInput | None = None,
+    t_sk: NumericInput | None = None,
     limit_inputs: bool = True,
     round_output: bool = True,
 ) -> PredictedBodyTemperatures:

--- a/pythermalcomfort/models/set_tmp.py
+++ b/pythermalcomfort/models/set_tmp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import SETInputs
+from pythermalcomfort.classes_input import NumericInput, SETInputs
 from pythermalcomfort.classes_return import SET
 from pythermalcomfort.models.two_nodes_gagge import two_nodes_gagge
 from pythermalcomfort.utilities import (
@@ -12,15 +12,15 @@ from pythermalcomfort.utilities import (
 
 
 def set_tmp(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0.0,
-    body_surface_area: float | list[float] = 1.8258,
-    p_atm: float | list[float] = 101325,
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0.0,
+    body_surface_area: NumericInput = 1.8258,
+    p_atm: NumericInput = 101325,
     position: str = Postures.standing.value,
     limit_inputs: bool = True,
     round_output: bool = True,

--- a/pythermalcomfort/models/solar_gain.py
+++ b/pythermalcomfort/models/solar_gain.py
@@ -4,21 +4,21 @@ import math
 
 import numpy as np
 
-from pythermalcomfort.classes_input import SolarGainInputs
+from pythermalcomfort.classes_input import NumericInput, SolarGainInputs
 from pythermalcomfort.classes_return import SolarGain
 from pythermalcomfort.utilities import Postures, transpose_sharp_altitude
 
 
 def solar_gain(
-    sol_altitude: float | list[float],
-    sharp: float | list[float],
-    sol_radiation_dir: float | list[float],
-    sol_transmittance: float | list[float],
-    f_svv: float | list[float],
-    f_bes: float | list[float],
-    asw: float | list[float] = 0.7,
+    sol_altitude: NumericInput,
+    sharp: NumericInput,
+    sol_radiation_dir: NumericInput,
+    sol_transmittance: NumericInput,
+    f_svv: NumericInput,
+    f_bes: NumericInput,
+    asw: NumericInput = 0.7,
     posture: str = Postures.sitting.value,
-    floor_reflectance: float | list[float] = 0.6,
+    floor_reflectance: NumericInput = 0.6,
     round_output: bool = True,
 ) -> SolarGain:
     """Calculate the solar gain to the human body using the Effective Radiant Field

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import numpy as np
 from scipy.optimize import brentq
 
-from pythermalcomfort.classes_input import SportsHeatStressInputs
+from pythermalcomfort.classes_input import NumericInput, SportsHeatStressInputs
 from pythermalcomfort.classes_return import SportsHeatStressRisk
 from pythermalcomfort.models import phs
 from pythermalcomfort.utilities import validate_type
@@ -45,9 +45,9 @@ class _SportsValues:
 class Sports:
     """Namespace of predefined sport values.
 
-    Use attributes like `Sports.RUNNING` to obtain a `_SportsValues` instance.
-    This class uses a frozen dataclass decorator to prevent modification of the
-    namespace. Attributes are class-level constants, not instance fields.
+    Use attributes like `Sports.RUNNING` to obtain a `_SportsValues` instance. This
+    class uses a frozen dataclass decorator to prevent modification of the namespace.
+    Attributes are class-level constants, not instance fields.
     """
 
     ABSEILING = _SportsValues(clo=0.6, met=6.0, vr=0.5, duration=120)
@@ -86,10 +86,10 @@ class Sports:
 
 
 def sports_heat_stress_risk(
-    tdb: float | list[float] | np.ndarray,
-    tr: float | list[float] | np.ndarray,
-    rh: float | list[float] | np.ndarray,
-    vr: float | list[float] | np.ndarray,
+    tdb: NumericInput | np.ndarray,
+    tr: NumericInput | np.ndarray,
+    rh: NumericInput | np.ndarray,
+    vr: NumericInput | np.ndarray,
     sport: _SportsValues,
 ) -> SportsHeatStressRisk:
     """Calculate sports heat stress risk levels based on environmental conditions and

--- a/pythermalcomfort/models/thi.py
+++ b/pythermalcomfort/models/thi.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import THIInputs
+from pythermalcomfort.classes_input import NumericInput, THIInputs
 from pythermalcomfort.classes_return import THI
 
 
 def thi(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
     round_output: bool = True,
 ) -> THI:
     """Calculate the Temperature-Humidity Index (THI) defined in [Yan2025]_, equivalent

--- a/pythermalcomfort/models/two_nodes_gagge.py
+++ b/pythermalcomfort/models/two_nodes_gagge.py
@@ -5,26 +5,26 @@ import math
 import numpy as np
 from numba import float64, jit, vectorize
 
-from pythermalcomfort.classes_input import GaggeTwoNodesInputs
+from pythermalcomfort.classes_input import GaggeTwoNodesInputs, NumericInput
 from pythermalcomfort.classes_return import SET, GaggeTwoNodes
 from pythermalcomfort.utilities import Postures, met_to_w_m2, p_sat_torr
 
 
 def two_nodes_gagge(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0,
-    body_surface_area: float | list[float] = 1.8258,
-    p_atm: float | list[float] = 101325,
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0,
+    body_surface_area: NumericInput = 1.8258,
+    p_atm: NumericInput = 101325,
     position: str = Postures.standing.value,
-    max_skin_blood_flow: float | list[float] = 90,
+    max_skin_blood_flow: NumericInput = 90,
     round_output: bool = True,
-    max_sweating: float | list[float] = 500,
-    w_max: float | list[float] = False,
+    max_sweating: NumericInput = 500,
+    w_max: NumericInput = False,
     calculate_ce: bool = False,
 ) -> SET | GaggeTwoNodes:
     """Gagge Two-node model of human temperature regulation Gagge et al (1986)

--- a/pythermalcomfort/models/two_nodes_gagge_ji.py
+++ b/pythermalcomfort/models/two_nodes_gagge_ji.py
@@ -4,21 +4,21 @@ import math
 
 import numpy as np
 
-from pythermalcomfort.classes_input import GaggeTwoNodesJiInputs
+from pythermalcomfort.classes_input import GaggeTwoNodesJiInputs, NumericInput
 from pythermalcomfort.classes_return import GaggeTwoNodesJi
 from pythermalcomfort.utilities import Postures
 
 
 def two_nodes_gagge_ji(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    vapor_pressure: float | list[float],
-    wme: float | list[float] = 0,
-    body_surface_area: float | list[float] = 1.8258,
-    p_atm: float | list[float] = 101325,
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    vapor_pressure: NumericInput,
+    wme: NumericInput = 0,
+    body_surface_area: NumericInput = 1.8258,
+    p_atm: NumericInput = 101325,
     position: str = Postures.sitting.value,
     **kwargs,
 ) -> GaggeTwoNodesJi:

--- a/pythermalcomfort/models/two_nodes_gagge_sleep.py
+++ b/pythermalcomfort/models/two_nodes_gagge_sleep.py
@@ -4,17 +4,17 @@ import math
 
 import numpy as np
 
-from pythermalcomfort.classes_input import GaggeTwoNodesSleepInputs
+from pythermalcomfort.classes_input import GaggeTwoNodesSleepInputs, NumericInput
 from pythermalcomfort.classes_return import GaggeTwoNodesSleep
 
 
 def two_nodes_gagge_sleep(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    clo: float | list[float],
-    thickness_quilt: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    clo: NumericInput,
+    thickness_quilt: NumericInput,
     wme: float = 0,
     p_atm: float = 101325,
     **kwargs,

--- a/pythermalcomfort/models/use_fans_heatwaves.py
+++ b/pythermalcomfort/models/use_fans_heatwaves.py
@@ -4,7 +4,7 @@ from dataclasses import asdict
 
 import numpy as np
 
-from pythermalcomfort.classes_input import UseFansHeatwavesInputs
+from pythermalcomfort.classes_input import NumericInput, UseFansHeatwavesInputs
 from pythermalcomfort.classes_return import UseFansHeatwaves
 from pythermalcomfort.models.two_nodes_gagge import two_nodes_gagge
 from pythermalcomfort.shared_functions import valid_range
@@ -12,15 +12,15 @@ from pythermalcomfort.utilities import Postures
 
 
 def use_fans_heatwaves(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    wme: float | list[float] = 0,
-    body_surface_area: float | list[float] = 1.8258,
-    p_atm: float | list[float] = 101325,
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    wme: NumericInput = 0,
+    body_surface_area: NumericInput = 1.8258,
+    p_atm: NumericInput = 101325,
     position: str = Postures.standing.value,
     max_skin_blood_flow: float = 80,
     max_sweating: float = 500,

--- a/pythermalcomfort/models/utci.py
+++ b/pythermalcomfort/models/utci.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import numpy as np
 from numba import float64, vectorize
 
-from pythermalcomfort.classes_input import UTCIInputs
+from pythermalcomfort.classes_input import NumericInput, UTCIInputs
 from pythermalcomfort.classes_return import UTCI
 from pythermalcomfort.shared_functions import mapping, valid_range
 from pythermalcomfort.utilities import Units, units_converter
 
 
 def utci(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
+    rh: NumericInput,
     units: str = Units.SI.value,
     limit_inputs: bool = True,
     round_output: bool = True,

--- a/pythermalcomfort/models/vertical_tmp_grad_ppd.py
+++ b/pythermalcomfort/models/vertical_tmp_grad_ppd.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import VerticalTGradPPDInputs
+from pythermalcomfort.classes_input import NumericInput, VerticalTGradPPDInputs
 from pythermalcomfort.classes_return import VerticalTGradPPD
 from pythermalcomfort.models import pmv_ppd_ashrae
 from pythermalcomfort.utilities import Models, _check_ashrae55_compliance
 
 
 def vertical_tmp_grad_ppd(
-    tdb: float | list[float],
-    tr: float | list[float],
-    vr: float | list[float],
-    rh: float | list[float],
-    met: float | list[float],
-    clo: float | list[float],
-    vertical_tmp_grad: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    vr: NumericInput,
+    rh: NumericInput,
+    met: NumericInput,
+    clo: NumericInput,
+    vertical_tmp_grad: NumericInput,
     round_output: bool = True,
     limit_inputs: bool = True,
 ) -> VerticalTGradPPD:

--- a/pythermalcomfort/models/wbgt.py
+++ b/pythermalcomfort/models/wbgt.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import numpy as np
-import numpy.typing as npt
 
-from pythermalcomfort.classes_input import WBGTInputs
+from pythermalcomfort.classes_input import NumericInput, WBGTInputs
 from pythermalcomfort.classes_return import WBGT
 
 
 def wbgt(
-    twb: float | npt.ArrayLike,
-    tg: float | npt.ArrayLike,
-    tdb: float | npt.ArrayLike = None,
+    twb: NumericInput,
+    tg: NumericInput,
+    tdb: NumericInput = None,
     with_solar_load: bool = False,
     round_output: bool = True,
 ) -> WBGT:

--- a/pythermalcomfort/models/wci.py
+++ b/pythermalcomfort/models/wci.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WCIInputs
+from pythermalcomfort.classes_input import NumericInput, WCIInputs
 from pythermalcomfort.classes_return import WCI
 
 
 def wci(
-    tdb: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    v: NumericInput,
     round_output: bool = True,
 ) -> WCI:
     """Calculate the Wind Chill Index (WCI) in accordance with the ASHRAE 2017 Handbook Fundamentals - Chapter 9 [ashrae2017]_.

--- a/pythermalcomfort/models/wind_chill_temperature.py
+++ b/pythermalcomfort/models/wind_chill_temperature.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WCTInputs
+from pythermalcomfort.classes_input import NumericInput, WCTInputs
 from pythermalcomfort.classes_return import WCT
 
 
 def wind_chill_temperature(
-    tdb: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    v: NumericInput,
     round_output: bool = True,
 ) -> WCT:
     """Calculate the Wind Chill Temperature (`WCT`_).

--- a/pythermalcomfort/models/work_capacity_dunne.py
+++ b/pythermalcomfort/models/work_capacity_dunne.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WorkCapacityHothapsInputs, WorkIntensity
+from pythermalcomfort.classes_input import (
+    NumericInput,
+    WorkCapacityHothapsInputs,
+    WorkIntensity,
+)
 from pythermalcomfort.classes_return import WorkCapacity
 
 
 def work_capacity_dunne(
-    wbgt: float | list[float],
+    wbgt: NumericInput,
     work_intensity: str = WorkIntensity.HEAVY.value,
 ) -> WorkCapacity:
     """Estimate work capacity due to heat based on Dunne et al [Dunne2013]_.

--- a/pythermalcomfort/models/work_capacity_hothaps.py
+++ b/pythermalcomfort/models/work_capacity_hothaps.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WorkCapacityHothapsInputs, WorkIntensity
+from pythermalcomfort.classes_input import (
+    NumericInput,
+    WorkCapacityHothapsInputs,
+    WorkIntensity,
+)
 from pythermalcomfort.classes_return import WorkCapacity
 
 
 def work_capacity_hothaps(
-    wbgt: float | list[float],
+    wbgt: NumericInput,
     work_intensity: str = WorkIntensity.HEAVY.value,
 ) -> WorkCapacity:
     """Estimate work capacity due to heat based on Kjellstrom et al. [Kjellstrom2018]_.

--- a/pythermalcomfort/models/work_capacity_iso.py
+++ b/pythermalcomfort/models/work_capacity_iso.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WorkCapacityStandardsInputs
+from pythermalcomfort.classes_input import NumericInput, WorkCapacityStandardsInputs
 from pythermalcomfort.classes_return import WorkCapacity
 
 
 def work_capacity_iso(
-    wbgt: float | list[float],
-    met: float | list[float],
+    wbgt: NumericInput,
+    met: NumericInput,
 ) -> WorkCapacity:
     """Estimate work capacity due to heat based on ISO standards as described by Brode
     et al.

--- a/pythermalcomfort/models/work_capacity_niosh.py
+++ b/pythermalcomfort/models/work_capacity_niosh.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import WorkCapacityStandardsInputs
+from pythermalcomfort.classes_input import NumericInput, WorkCapacityStandardsInputs
 from pythermalcomfort.classes_return import WorkCapacity
 
 
 def work_capacity_niosh(
-    wbgt: float | list[float],
-    met: float | list[float],
+    wbgt: NumericInput,
+    met: NumericInput,
 ) -> WorkCapacity:
     """Estimate work capacity due to heat based on NIOSH standards as described by Brode
     et al.

--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -11,6 +11,8 @@ from numpy.typing import NDArray
 from pythermalcomfort.classes_return import PsychrometricValues
 from pythermalcomfort.shared_functions import _format_violation_detail, valid_range
 
+NumericInput = float | int | np.ndarray | list
+
 warnings.simplefilter("always")
 
 
@@ -48,7 +50,7 @@ class Sex(Enum):
     female = "female"
 
 
-def p_sat_torr(tdb: float | list[float]) -> NDArray[np.float64]:
+def p_sat_torr(tdb: NumericInput) -> NDArray[np.float64]:
     """Estimates the saturation vapor pressure in [torr].
 
     Parameters
@@ -66,8 +68,8 @@ def p_sat_torr(tdb: float | list[float]) -> NDArray[np.float64]:
 
 
 def enthalpy_air(
-    tdb: float | list[float] | NDArray[np.float64],
-    hr: float | list[float] | NDArray[np.float64],
+    tdb: NumericInput,
+    hr: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate air enthalpy_air.
 
@@ -90,7 +92,7 @@ def enthalpy_air(
     return h_dry_air + hr * h_sat_vap
 
 
-def p_sat(tdb: float | list[float] | NDArray[np.float64]) -> NDArray[np.float64]:
+def p_sat(tdb: NumericInput) -> NDArray[np.float64]:
     """Calculate vapour pressure of water at different temperatures.
 
     Parameters
@@ -136,7 +138,7 @@ def p_sat(tdb: float | list[float] | NDArray[np.float64]) -> NDArray[np.float64]
     )
 
 
-def antoine(tdb: float | list[float]) -> NDArray[np.float64]:
+def antoine(tdb: NumericInput) -> NDArray[np.float64]:
     """Calculate saturated vapor pressure using Antoine equation [kPa].
 
     Parameters
@@ -154,8 +156,8 @@ def antoine(tdb: float | list[float]) -> NDArray[np.float64]:
 
 
 def psy_ta_rh(
-    tdb: float | list[float],
-    rh: float | list[float],
+    tdb: NumericInput,
+    rh: NumericInput,
     p_atm: float = 101325,
 ) -> PsychrometricValues:
     """Calculate psychrometric values of air based on dry bulb air temperature and
@@ -210,8 +212,8 @@ def psy_ta_rh(
 
 
 def wet_bulb_tmp(
-    tdb: float | list[float] | NDArray[np.float64],
-    rh: float | list[float] | NDArray[np.float64],
+    tdb: NumericInput,
+    rh: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate the wet-bulb temperature using the Stull equation [Stull2011]_.
 
@@ -240,8 +242,8 @@ def wet_bulb_tmp(
 
 
 def dew_point_tmp(
-    tdb: float | list[float] | NDArray[np.float64],
-    rh: float | list[float] | NDArray[np.float64],
+    tdb: NumericInput,
+    rh: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate the dew point temperature.
 
@@ -287,11 +289,11 @@ def dew_point_tmp(
 
 
 def mean_radiant_tmp(
-    tg: float | list[float],
-    tdb: float | list[float],
-    v: float | list[float],
-    d: float | list[float] = 0.15,
-    emissivity: float | list[float] = 0.95,
+    tg: NumericInput,
+    tdb: NumericInput,
+    v: NumericInput,
+    d: NumericInput = 0.15,
+    emissivity: NumericInput = 0.95,
     standard="Mixed Convection",
 ) -> NDArray[np.float64]:
     """Convert the globe temperature reading into mean radiant temperature in accordance
@@ -642,8 +644,8 @@ def f_svv(w: float, h: float, d: float) -> float:
 
 
 def v_relative(
-    v: float | list[float] | NDArray[np.float64],
-    met: float | list[float] | NDArray[np.float64],
+    v: NumericInput,
+    met: NumericInput,
 ) -> NDArray[np.float64]:
     """Estimates the relative air speed which combines the average air speed of the
     space plus the relative air speed caused by the body movement. The same equation is
@@ -667,8 +669,8 @@ def v_relative(
 
 
 def clo_dynamic_ashrae(
-    clo: float | list[float],
-    met: float | list[float],
+    clo: NumericInput,
+    met: NumericInput,
     model: str = Models.ashrae_55_2023.value,
 ) -> np.ndarray:
     """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`).
@@ -713,10 +715,10 @@ def clo_dynamic_ashrae(
 
 
 def clo_dynamic_iso(
-    clo: float | list[float],
-    met: float | list[float],
-    v: float | list[float],
-    i_a: float | list[float] = 0.7,
+    clo: NumericInput,
+    met: NumericInput,
+    v: NumericInput,
+    i_a: NumericInput = 0.7,
     model: str = Models.iso_9920_2007.value,
 ) -> np.ndarray:
     """Estimates the dynamic intrinsic clothing insulation (I :sub:`cl,r`).
@@ -945,9 +947,9 @@ def units_converter(from_units=Units.IP.value, **kwargs) -> list[float]:
 
 
 def operative_tmp(
-    tdb: float | list[float],
-    tr: float | list[float],
-    v: float | list[float],
+    tdb: NumericInput,
+    tr: NumericInput,
+    v: NumericInput,
     standard: str = "ISO",
 ) -> NDArray[np.float64]:
     """Calculate the operative temperature in accordance with ISO 7726:1998
@@ -987,7 +989,7 @@ def operative_tmp(
 
 
 def clo_intrinsic_insulation_ensemble(
-    clo_garments: float | list[float],
+    clo_garments: NumericInput,
 ) -> float:
     """Calculate the intrinsic insulation of a clothing ensemble based on individual
     garments.
@@ -1011,7 +1013,7 @@ def clo_intrinsic_insulation_ensemble(
 
 
 def clo_area_factor(
-    i_cl: float | list[float] | NDArray[np.float64],
+    i_cl: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate the clothing area factor (f_cl) of the clothing ensemble as a function
     of the intrinsic insulation of the clothing ensemble. This equation is in accordance
@@ -1036,9 +1038,9 @@ def clo_area_factor(
 
 # TODO implement the vr and v_walk functions as a function of the met
 def clo_insulation_air_layer(
-    vr: float | list[float] | NDArray[np.float64],
-    v_walk: float | list[float] | NDArray[np.float64],
-    i_a_static: float | list[float] | NDArray[np.float64],
+    vr: NumericInput,
+    v_walk: NumericInput,
+    i_a_static: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate the insulation of the boundary air layer (`I`:sub:`a,r`).
 
@@ -1080,11 +1082,11 @@ def clo_insulation_air_layer(
 
 
 def clo_total_insulation(
-    i_t: float | list[float] | NDArray[np.float64],
-    vr: float | list[float] | NDArray[np.float64],
-    v_walk: float | list[float] | NDArray[np.float64],
-    i_a_static: float | list[float] | NDArray[np.float64],
-    i_cl: float | list[float] | NDArray[np.float64],
+    i_t: NumericInput,
+    vr: NumericInput,
+    v_walk: NumericInput,
+    i_a_static: NumericInput,
+    i_cl: NumericInput,
 ) -> NDArray[np.float64]:
     """Calculate the total insulation of the clothing ensemble (`I`:sub:`T,r`).
 
@@ -1149,9 +1151,9 @@ def clo_total_insulation(
 
 
 def clo_correction_factor_environment(
-    vr: float | list[float],
-    v_walk: float | list[float],
-    i_cl: float | list[float],
+    vr: NumericInput,
+    v_walk: NumericInput,
+    i_cl: NumericInput,
 ) -> NDArray[np.float64]:
     """Return the correction factor for the total insulation of the clothing ensemble
     (`I`:sub:`T`) or the basic/intrinsic insulation (`I`:sub:`cl`).

--- a/pythermalcomfort/utils/scale_wind_speed_log.py
+++ b/pythermalcomfort/utils/scale_wind_speed_log.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import numpy as np
 
-from pythermalcomfort.classes_input import ScaleWindSpeedLogInputs
+from pythermalcomfort.classes_input import NumericInput, ScaleWindSpeedLogInputs
 from pythermalcomfort.classes_return import ScaleWindSpeedLog
 
 
 def scale_wind_speed_log(
-    v_z1: float | list[float],
-    z2: float | list[float],
-    z1: float | list[float] = 10.0,
-    z0: float | list[float] = 0.01,
-    d: float | list[float] = 0.0,
+    v_z1: NumericInput,
+    z2: NumericInput,
+    z1: NumericInput = 10.0,
+    z0: NumericInput = 0.01,
+    d: NumericInput = 0.0,
     round_output: bool = True,
 ) -> ScaleWindSpeedLog:
     """Scale wind speed from the reference height to a user specified height using the


### PR DESCRIPTION
## What this PR does

Rolls out the `NumericInput` type alias (`float | int | np.ndarray | list`) across pythermalcomfort, replacing the inconsistent `float | list[float]` unions on public APIs. Structured as 3 independently revertable commits:

1. `0a16872` — `NumericInput` on 37 model function signatures
2. `0919420` — `NumericInput` on `utilities.py` (53 sites) and `utils/scale_wind_speed_log.py` (5); also **moves the canonical `NumericInput` definition to `utilities.py`**
3. `8320415` — `NumericInput` on 94 dataclass fields in `classes_return.py`

## Why this change is needed

The previous `float | list[float]` union under-described what the functions actually accept (also `int` and `np.ndarray`), caused a misleading "np.ndarray not in declared type" warning in PyCharm, and was too verbose in the IDE signature popup. `NumericInput` resolves all three.

Scope is extended beyond plain function signatures to dataclass fields, since those turned out to be the main source of the IDE warnings. The 3-commit split lets the extended scope be reviewed (and reverted) independently.

## Design note

- `NumericInput` is defined in **one place** — `pythermalcomfort/utilities.py`. Picked this module because `classes_input.py` already imports from `utilities.py` (for `Postures`, `Sex`, etc.), so putting `NumericInput` here keeps the import direction one-way and avoids any chance of a circular import.
- `classes_input.py` still exposes `NumericInput` — it imports it from `utilities.py` and re-exports it. This means every model file's existing `from pythermalcomfort.classes_input import NumericInput` keeps working with no change.
- `classes_return.py` is a special case: `utilities.py` already imports `PsychrometricValues` from it, so importing `NumericInput` from `utilities.py` would create a circular import. To avoid that, `classes_return.py` only imports `NumericInput` under `if TYPE_CHECKING:` — a guard that the Python runtime skips. This is safe here because the file uses `from __future__ import annotations` (which tells Python to treat all annotations as plain strings rather than evaluating them), and no code in the project inspects these annotations at runtime.

## How I tested it

- [x] `pytest` — 335 passed / 1 xfailed
- [x] `pre-commit` hooks pass (ruff check, ruff format, docformatter)
- [x] PyCharm signature popup checked manually: shows compact `NumericInput`, no false np.ndarray warning

## Notes for reviewers

- Each of the 3 commits stands alone — any one can be reverted individually if it exceeds desired scope.
- Incidental fixes in commit 1 :
  - `pet_steady.sex` annotation `int` → `str` (implementation already accepted strings)
  - `pet_steady.age` annotation broadened to `NumericInput`
  - `phs.wme` annotation extended to accept an int scalar
- Intentionally **out of scope**: `bool | list[bool]` and `str | list[str]` dataclass fields (e.g. `acceptability_*`, `discomfort_condition`) — same conceptual issue but outside the literal `float | list[float]` scope of #325;