### PR TITLE
feat: release 4.0.2 — dynamic extreme range in sports heat stress risk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,14 @@
 Changelog
 =========
 
-4.0.2 (unreleased)
+4.0.2 (2026-06-23)
 ------------------
 
 * Improved sports heat stress risk interpolation within the extreme range: the
   upper anchor temperature (where risk reaches 4.9) is now computed dynamically
-  as ``t_extreme + 5 °C`` instead of a fixed 50 °C ceiling. This makes the
-  extreme-range scale consistent across humidity conditions — the risk always
-  spans exactly 5 °C above the humidity-dependent extreme threshold regardless
-  of ambient conditions.
+  as ``t_extreme + 5 °C``. This makes the extreme-range scale consistent across
+  humidity conditions — the risk always spans exactly 5 °C above the
+  humidity-dependent extreme threshold regardless of ambient conditions.
 
 4.0.1 (2026-06-17)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+4.0.2 (unreleased)
+------------------
+
+* Improved sports heat stress risk interpolation within the extreme range: the
+  upper anchor temperature (where risk reaches 4.9) is now computed dynamically
+  as ``t_extreme + 5 °C`` instead of a fixed 50 °C ceiling. This makes the
+  extreme-range scale consistent across humidity conditions — the risk always
+  spans exactly 5 °C above the humidity-dependent extreme threshold regardless
+  of ambient conditions.
+
 4.0.1 (2026-06-17)
 ------------------
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ pre-commit run --all-files
    git push origin master --tags
    ```
 6. **Confirm** the `Test and publish pythermalcomfort` action succeeded and the package is live on PyPI.
+7. **Sync master back into development** so the version-bump commit is not lost:
+   ```bash
+   git checkout development && git pull
+   git merge origin/master --no-edit
+   git push origin development
+   ```
 
 > **Note**: RC tags (`v*rc*`) must be created from `development` — the CI workflow enforces
 > this with a `merge-base` check. Final release tags (`v*`) must be created from `master`.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -277,6 +277,23 @@ As a convention, functions should return structured dataclasses where applicable
 - Add a short line to the changelog describing the new function.
 - Optionally add yourself to AUTHORS.rst when contributing a new feature.
 
+Release process (maintainers only)
+===================================
+
+After each release, the version-bump commit on ``master`` must be merged back
+into ``development`` so the two branches stay in sync:
+
+.. code-block:: bash
+
+    git checkout development && git pull
+    git merge origin/master --no-edit
+    git push origin development
+
+Failing to do this means ``development`` will be behind ``master`` and the next
+RC tag will be rejected by the CI ``merge-base`` check.
+
+See ``CLAUDE.md`` for the full step-by-step release process.
+
 8) Formatting, linting and tests locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,6 +58,7 @@ Setting up your development environment:
     cd pythermalcomfort
     git remote add upstream git@github.com:pythermalcomfort/pythermalcomfort.git
     git fetch upstream
+    git checkout development
 
 2. Set up a virtual environment and install dependencies, you should have Python 3.12+ installed and `pipenv <https://pipenv.pypa.io/en/latest/>`_ available:
 
@@ -66,7 +67,7 @@ Setting up your development environment:
     pip install pipenv
     pipenv sync --dev
 
-3. Create a feature branch (use the naming rules below):
+3. Create a feature branch based on the development branch, with a descriptive name for example:
 
 .. code-block:: bash
 
@@ -145,6 +146,7 @@ Quick checklist (use before opening a PR)
 - [ ] All tests pass and formatting/linting applied.
 - [ ] Add the function to ``__init__.py`` which is located in the ``pythermalcomfort/models/`` folder.
 - [ ] The function should accept both scalar and vectorized inputs (lists, numpy arrays) and return outputs of matching shape.
+- [ ] Optional but important: optimise for performance using Numba and NumPy vectorized operations.
 
 Step-by-step guide
 ------------------

--- a/pythermalcomfort/classes_return.py
+++ b/pythermalcomfort/classes_return.py
@@ -1077,8 +1077,9 @@ class SportsHeatStressRisk(AutoStrMixin):
     Attributes
     ----------
     risk_level_interpolated : float or list of floats
-        Interpolated risk level (1.0-4.0), [dimensionless].
-        Risk levels: 1-<2 = low, 2-<3 = moderate, 3-<4 = high, 4 = extreme.
+        Interpolated risk level (1.0-4.9), [dimensionless].
+        Risk levels: 1-<2 = low, 2-<3 = moderate, 3-<4 = high,
+        4-4.9 = extreme.
     t_medium : float or list of floats
         Temperature threshold for medium risk level, [°C].
     t_high : float or list of floats

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -261,6 +261,7 @@ def _calc_risk_single_value(
             min_t_extreme,
             _get_recommendation(1.0),
         )
+
     def calculate_threshold_water_loss(x):
         sl = phs(
             tdb=x,
@@ -358,9 +359,7 @@ def _calc_risk_single_value(
     elif t_medium <= tdb < t_high:
         risk_level_interpolated = 2.0 + (tdb - t_medium) / (t_high - t_medium)
     elif t_high <= tdb < extreme_entry_t:
-        risk_level_interpolated = 3.0 + (tdb - t_high) / (
-            extreme_entry_t - t_high
-        )
+        risk_level_interpolated = 3.0 + (tdb - t_high) / (extreme_entry_t - t_high)
     elif tdb >= extreme_entry_t:
         risk_level_interpolated = 4.0 + (tdb - extreme_entry_t) / (
             t_upper_extreme - extreme_entry_t

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -244,7 +244,8 @@ def _calc_risk_single_value(
     max_t_low = 34.5  # maximum tdb for low risk
     max_t_medium = 39  # maximum tdb for medium risk
     max_t_high = 43.5  # maximum tdb for high risk
-    t_upper_extreme = 50.0  # upper tdb anchor for interpolating extreme risk
+    # risk 4.9 is reached 5°C above the humidity-dependent extreme threshold
+    t_upper_extreme_delta = 5.0
     min_t_low = 21  # minimum tdb for low risk
     min_t_medium = 23  # minimum tdb for medium risk
     min_t_high = 25  # minimum tdb for high risk
@@ -361,9 +362,7 @@ def _calc_risk_single_value(
     elif t_high <= tdb < extreme_entry_t:
         risk_level_interpolated = 3.0 + (tdb - t_high) / (extreme_entry_t - t_high)
     elif tdb >= extreme_entry_t:
-        risk_level_interpolated = 4.0 + (tdb - extreme_entry_t) / (
-            t_upper_extreme - extreme_entry_t
-        )
+        risk_level_interpolated = 4.0 + (tdb - extreme_entry_t) / t_upper_extreme_delta
 
     if np.isnan(risk_level_interpolated):
         raise ValueError("Risk level could not be determined due to NaN thresholds.")

--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -244,6 +244,7 @@ def _calc_risk_single_value(
     max_t_low = 34.5  # maximum tdb for low risk
     max_t_medium = 39  # maximum tdb for medium risk
     max_t_high = 43.5  # maximum tdb for high risk
+    t_upper_extreme = 50.0  # upper tdb anchor for interpolating extreme risk
     min_t_low = 21  # minimum tdb for low risk
     min_t_medium = 23  # minimum tdb for medium risk
     min_t_high = 25  # minimum tdb for high risk
@@ -260,16 +261,6 @@ def _calc_risk_single_value(
             min_t_extreme,
             _get_recommendation(1.0),
         )
-    if tdb > max_t_high:
-        # Extreme risk - use maximum thresholds and risk level 4
-        return (
-            4.0,
-            max_t_low,
-            max_t_medium,
-            max_t_high,
-            _get_recommendation(4.0),
-        )
-
     def calculate_threshold_water_loss(x):
         sl = phs(
             tdb=x,
@@ -359,22 +350,27 @@ def _calc_risk_single_value(
     if t_medium < min_t_medium:
         t_medium = min_t_medium
 
+    extreme_entry_t = min(t_extreme, max_t_high)
     risk_level_interpolated = np.nan
     # calculate the risk level with one decimal place
     if min_t_low <= tdb < t_medium:
         risk_level_interpolated = 1.0 + (tdb - min_t_medium) / (t_medium - min_t_medium)
     elif t_medium <= tdb < t_high:
         risk_level_interpolated = 2.0 + (tdb - t_medium) / (t_high - t_medium)
-    elif t_high <= tdb < t_extreme:
-        risk_level_interpolated = 3.0 + (tdb - t_high) / (t_extreme - t_high)
-    elif tdb >= t_extreme:
-        risk_level_interpolated = 4.0
+    elif t_high <= tdb < extreme_entry_t:
+        risk_level_interpolated = 3.0 + (tdb - t_high) / (
+            extreme_entry_t - t_high
+        )
+    elif tdb >= extreme_entry_t:
+        risk_level_interpolated = 4.0 + (tdb - extreme_entry_t) / (
+            t_upper_extreme - extreme_entry_t
+        )
 
     if np.isnan(risk_level_interpolated):
         raise ValueError("Risk level could not be determined due to NaN thresholds.")
 
     # Truncate to one decimal place toward negative infinity.
-    risk_level_floor = np.floor(risk_level_interpolated * 10.0) / 10.0
+    risk_level_floor = min(np.floor(risk_level_interpolated * 10.0) / 10.0, 4.9)
 
     # Generate recommendation based on the FLOORED risk level for consistency
     recommendation = _get_recommendation(risk_level_floor)
@@ -394,7 +390,7 @@ def _get_recommendation(risk_level: float) -> str:
     Parameters
     ----------
     risk_level : float
-        Interpolated risk level (1.0-4.0).
+        Interpolated risk level (1.0-4.9).
 
     Returns
     -------

--- a/tests/test_sports_heat_stress_risk.py
+++ b/tests/test_sports_heat_stress_risk.py
@@ -364,7 +364,8 @@ def test_sports_heat_stress_risk_extreme_interpolation():
         tdb=45.0, tr=20, rh=0, vr=10, sport=Sports.FISHING
     )
     assert mid_result.t_extreme == pytest.approx(43.5, abs=0.01)
-    assert mid_result.risk_level_interpolated == pytest.approx(4.2, abs=0.01)
+    # With t_upper_extreme = t_extreme + 5, risk at tdb=45 is 4.0 + (45 - 43.5) / 5 = 4.3
+    assert mid_result.risk_level_interpolated == pytest.approx(4.3, abs=0.01)
 
     capped_result = sports_heat_stress_risk(
         tdb=50.0, tr=20, rh=0, vr=10, sport=Sports.FISHING

--- a/tests/test_sports_heat_stress_risk.py
+++ b/tests/test_sports_heat_stress_risk.py
@@ -18,7 +18,7 @@ from pythermalcomfort.models.sports_heat_stress_risk import (
         # Low temperature (low risk)
         (10, 20, 40, 2, Sports.MTB, 1.0),
         # Very high temperature (extreme risk)
-        (60, 20, 40, 2, Sports.MTB, 4.0),
+        (60, 20, 40, 2, Sports.MTB, 4.9),
         # Different sport
         (35, 35, 50, 0.5, Sports.RUNNING, 2.1),
     ],
@@ -131,7 +131,7 @@ def test_sports_heat_stress_risk_numpy_array():
 
     # Verify all values are valid
     for risk in result.risk_level_interpolated:
-        assert 1 <= risk <= 4
+        assert 1 <= risk <= 4.9
 
 
 def test_sports_heat_stress_risk_different_sports():
@@ -152,8 +152,8 @@ def test_sports_heat_stress_risk_different_sports():
     assert isinstance(result_running, SportsHeatStressRisk)
     assert isinstance(result_walking, SportsHeatStressRisk)
     # Both should return valid risk levels
-    assert 1 <= result_running.risk_level_interpolated <= 4
-    assert 1 <= result_walking.risk_level_interpolated <= 4
+    assert 1 <= result_running.risk_level_interpolated <= 4.9
+    assert 1 <= result_walking.risk_level_interpolated <= 4.9
 
 
 def test_sports_heat_stress_risk_invalid_inputs():
@@ -276,12 +276,12 @@ def test_sports_heat_stress_risk_recommendations():
         result.recommendation
     )
 
-    # Test extreme risk (risk level = 4.0)
+    # Test extreme risk (risk level = 4.9 at the upper temperature anchor)
     result_extreme = sports_heat_stress_risk(
         tdb=50, tr=50, rh=50, vr=0.5, sport=Sports.RUNNING
     )
     assert "Consider suspending play" in str(result_extreme.recommendation)
-    assert result_extreme.risk_level_interpolated == pytest.approx(4.0, rel=1e-3)
+    assert result_extreme.risk_level_interpolated == pytest.approx(4.9, rel=1e-3)
 
 
 def test_sports_heat_stress_risk_array_recommendations():
@@ -327,10 +327,10 @@ def test_sports_heat_stress_risk_threshold_capping():
     )
 
     # Verify thresholds respect minimum bounds (from implementation)
-    # min_t_medium = 22, min_t_high = 23, min_t_extreme = 25
-    assert result_low.t_medium >= 22.0
-    assert result_low.t_high >= 23.0
-    assert result_low.t_extreme >= 25.0
+    # min_t_medium = 23, min_t_high = 25, min_t_extreme = 26
+    assert result_low.t_medium >= 23.0
+    assert result_low.t_high >= 25.0
+    assert result_low.t_extreme >= 26.0
 
     # Verify threshold ordering is always maintained
     assert result_high.t_medium < result_high.t_high < result_high.t_extreme
@@ -345,11 +345,45 @@ def test_sports_heat_stress_risk_edge_temperature_ranges():
     )
     assert result_very_low.risk_level_interpolated == pytest.approx(1.0, abs=0.01)
 
-    # Test very high temperature (should be extreme risk, risk_level = 4)
+    # Test very high temperature (should be capped at the upper extreme risk level)
     result_very_high = sports_heat_stress_risk(
         tdb=50, tr=50, rh=50, vr=0.5, sport=Sports.RUNNING
     )
-    assert result_very_high.risk_level_interpolated == pytest.approx(4.0, abs=0.01)
+    assert result_very_high.risk_level_interpolated == pytest.approx(4.9, abs=0.01)
+
+
+def test_sports_heat_stress_risk_extreme_interpolation():
+    """Test interpolation within the extreme risk range up to 4.9."""
+    anchor_result = sports_heat_stress_risk(
+        tdb=43.5, tr=20, rh=0, vr=10, sport=Sports.FISHING
+    )
+    assert anchor_result.t_extreme == pytest.approx(43.5, abs=0.01)
+    assert anchor_result.risk_level_interpolated == pytest.approx(4.0, abs=0.01)
+
+    mid_result = sports_heat_stress_risk(
+        tdb=45.0, tr=20, rh=0, vr=10, sport=Sports.FISHING
+    )
+    assert mid_result.t_extreme == pytest.approx(43.5, abs=0.01)
+    assert mid_result.risk_level_interpolated == pytest.approx(4.2, abs=0.01)
+
+    capped_result = sports_heat_stress_risk(
+        tdb=50.0, tr=20, rh=0, vr=10, sport=Sports.FISHING
+    )
+    assert capped_result.risk_level_interpolated == pytest.approx(4.9, abs=0.01)
+
+
+def test_sports_heat_stress_risk_extreme_interpolation_uses_lower_model_threshold():
+    """Test that severe conditions start extreme interpolation below 43.5°C."""
+    base_result = sports_heat_stress_risk(
+        tdb=45.0, tr=45.0, rh=100, vr=0, sport=Sports.RUNNING
+    )
+    severe_result = sports_heat_stress_risk(
+        tdb=45.0, tr=50.0, rh=100, vr=0, sport=Sports.RUNNING
+    )
+
+    assert severe_result.t_extreme < 43.5
+    assert severe_result.risk_level_interpolated >= 4.0
+    assert severe_result.risk_level_interpolated >= base_result.risk_level_interpolated
 
 
 def test_sports_heat_stress_risk_all_sports():
@@ -402,7 +436,7 @@ def test_sports_heat_stress_risk_all_sports():
         assert isinstance(result.risk_level_interpolated, (float, np.ndarray))
         # Convert to float for comparison
         risk_value = float(np.asarray(result.risk_level_interpolated).item())
-        assert 1 <= risk_value <= 4
+        assert 1 <= risk_value <= 4.9
         assert isinstance(result.t_medium, (float, np.ndarray))
         assert isinstance(result.t_high, (float, np.ndarray))
         assert isinstance(result.t_extreme, (float, np.ndarray))
@@ -441,7 +475,7 @@ def test_sports_heat_stress_risk_boundary_values(tdb, tr, rh, vr, sport):
     assert isinstance(result.risk_level_interpolated, (float, np.ndarray))
     # Convert to float for comparison
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
     assert isinstance(result.t_medium, (float, np.ndarray))
     assert isinstance(result.t_high, (float, np.ndarray))
     assert isinstance(result.t_extreme, (float, np.ndarray))
@@ -477,7 +511,7 @@ def test_sports_heat_stress_risk_very_large_wind_speed():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Extreme wind speed
     result = sports_heat_stress_risk(
@@ -485,7 +519,7 @@ def test_sports_heat_stress_risk_very_large_wind_speed():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
 
 def test_sports_heat_stress_risk_extreme_cold_temperatures():
@@ -514,14 +548,14 @@ def test_sports_heat_stress_risk_extreme_hot_temperatures():
     result = sports_heat_stress_risk(tdb=70, tr=70, rh=10, vr=0.5, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    # Should be extreme risk (4.0)
-    assert risk_value == pytest.approx(4.0, abs=0.01)
+    # Should be capped at the upper extreme risk level
+    assert risk_value == pytest.approx(4.9, abs=0.01)
 
     # Industrial environment extreme heat
     result = sports_heat_stress_risk(tdb=80, tr=80, rh=50, vr=0.1, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(4.0, abs=0.01)
+    assert risk_value == pytest.approx(4.9, abs=0.01)
 
 
 def test_sports_heat_stress_risk_zero_values():
@@ -530,13 +564,13 @@ def test_sports_heat_stress_risk_zero_values():
     result = sports_heat_stress_risk(tdb=0, tr=0, rh=0, vr=0, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Zero humidity and wind
     result = sports_heat_stress_risk(tdb=25, tr=25, rh=0, vr=0, sport=Sports.SOCCER)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
 
 def test_sports_heat_stress_risk_very_small_positive_values():
@@ -546,7 +580,7 @@ def test_sports_heat_stress_risk_very_small_positive_values():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Very small but valid humidity
     result = sports_heat_stress_risk(
@@ -554,7 +588,7 @@ def test_sports_heat_stress_risk_very_small_positive_values():
     )
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
 
 def test_sports_heat_stress_risk_float_precision_edge_cases():
@@ -605,7 +639,7 @@ def test_sports_heat_stress_risk_large_array():
     # Verify all values are valid
     for i in range(size):
         risk = float(np.asarray(result.risk_level_interpolated[i]).item())
-        assert 1 <= risk <= 4
+        assert 1 <= risk <= 4.9
         assert not np.isnan(risk)
 
 
@@ -615,13 +649,13 @@ def test_sports_heat_stress_risk_mixed_extreme_conditions():
     result = sports_heat_stress_risk(tdb=45, tr=50, rh=100, vr=0, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert risk_value == pytest.approx(4.0, abs=0.01)
+    assert 4.0 <= risk_value <= 4.9
 
     # High temp + low humidity + high wind (best cooling case)
     result = sports_heat_stress_risk(tdb=40, tr=40, rh=5, vr=10.0, sport=Sports.CYCLING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Cold + high humidity + high wind (hypothermia risk, but not heat stress)
     result = sports_heat_stress_risk(
@@ -638,19 +672,19 @@ def test_sports_heat_stress_risk_radiant_temperature_extremes():
     result = sports_heat_stress_risk(tdb=30, tr=70, rh=40, vr=0.5, sport=Sports.TENNIS)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Very low radiant temperature (shade)
     result = sports_heat_stress_risk(tdb=35, tr=20, rh=50, vr=0.5, sport=Sports.SOCCER)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Extreme radiant heat (hot surfaces)
     result = sports_heat_stress_risk(tdb=30, tr=80, rh=30, vr=1.0, sport=Sports.RUNNING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
 
 def test_sports_heat_stress_risk_negative_radiant_temperature():
@@ -659,7 +693,7 @@ def test_sports_heat_stress_risk_negative_radiant_temperature():
     result = sports_heat_stress_risk(tdb=20, tr=-5, rh=40, vr=0.5, sport=Sports.WALKING)
     assert isinstance(result, SportsHeatStressRisk)
     risk_value = float(np.asarray(result.risk_level_interpolated).item())
-    assert 1 <= risk_value <= 4
+    assert 1 <= risk_value <= 4.9
 
     # Very cold radiant surfaces
     result = sports_heat_stress_risk(
@@ -778,7 +812,7 @@ def test_sports_heat_stress_risk_stress_gradient():
         risks.append(risk_value)
 
     # Risk should generally increase with temperature
-    # (allowing for some flatness at the extremes where risk is capped at 1 or 4)
+    # (allowing for some flatness at the extremes where risk is capped at 1 or 4.9)
     for i in range(1, len(risks)):
         assert risks[i] >= risks[i - 1], (
             f"Risk decreased from {risks[i - 1]} to {risks[i]} when temperature increased from {temps[i - 1]} to {temps[i]}"


### PR DESCRIPTION
## Summary

- **Sports heat stress risk improvement**: the upper anchor temperature for extreme risk interpolation is now computed dynamically as `t_extreme + 5 °C` instead of a fixed 50 °C ceiling. Risk 4.9 is always reached exactly 5 °C above the humidity-dependent extreme threshold, making the scale consistent across conditions.
- Merged `master` → `development` to sync the 4.0.1 final version bump.
- Updated `CHANGELOG.rst` with the 4.0.2 entry.
- Updated `CLAUDE.md` and `CONTRIBUTING.rst` to document the post-release master→development sync step.

## Test plan

- [ ] All existing tests pass (`pytest tests/test_sports_heat_stress_risk.py`)
- [ ] CI passes on this PR
- [ ] After merge: checkout master, bump to 4.0.2, tag `v4.0.2`, push to trigger PyPI deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)