### PR TITLE
feat: add Croquet sports heat stress preset

### DIFF
--- a/pythermalcomfort/models/sports_heat_stress_risk.py
+++ b/pythermalcomfort/models/sports_heat_stress_risk.py
@@ -58,6 +58,7 @@ class Sports:
     BOWLS = _SportsValues(clo=0.5, met=5.0, vr=0.5, duration=180)
     CANOEING = _SportsValues(clo=0.6, met=7.5, vr=2.0, duration=60)
     CRICKET = _SportsValues(clo=0.7, met=6.0, vr=0.75, duration=120)
+    CROQUET = _SportsValues(clo=0.7, met=4.5, vr=0.5, duration=90)
     CYCLING = _SportsValues(clo=0.4, met=7.0, vr=3.0, duration=60)
     EQUESTRIAN = _SportsValues(clo=0.9, met=7.4, vr=3.0, duration=60)
     FIELD_ATHLETICS = _SportsValues(clo=0.3, met=7.0, vr=1.0, duration=60)

--- a/tests/test_sports_heat_stress_risk.py
+++ b/tests/test_sports_heat_stress_risk.py
@@ -387,6 +387,16 @@ def test_sports_heat_stress_risk_extreme_interpolation_uses_lower_model_threshol
     assert severe_result.risk_level_interpolated >= base_result.risk_level_interpolated
 
 
+def test_sports_croquet_values():
+    """Test Croquet preset values."""
+    assert (Sports.CROQUET.clo, Sports.CROQUET.met, Sports.CROQUET.vr) == (
+        0.7,
+        4.5,
+        0.5,
+    )
+    assert Sports.CROQUET.duration == 90
+
+
 def test_sports_heat_stress_risk_all_sports():
     """Test that all predefined sports in Sports dataclass work correctly."""
     # Get all sport attributes from Sports dataclass
@@ -399,6 +409,7 @@ def test_sports_heat_stress_risk_all_sports():
         Sports.BOWLS,
         Sports.CANOEING,
         Sports.CRICKET,
+        Sports.CROQUET,
         Sports.CYCLING,
         Sports.EQUESTRIAN,
         Sports.FIELD_ATHLETICS,


### PR DESCRIPTION
## Summary
- Add `Sports.CROQUET` preset (`clo=0.7, met=4.5, vr=0.5, duration=90`) to `sports_heat_stress_risk.py`
- Add corresponding unit test and registration in the all-sports test

Based on yehui-h's `feature/add_croquet_to_sports` branch, with the comparison plotting script and generated PNGs intentionally left out to keep the PR scoped to the model addition.

## Test plan
- [x] `pytest tests/test_sports_heat_stress_risk.py` — 42 passed, 1 pre-existing unrelated failure (`test_sports_heat_stress_risk_extreme_interpolation`, reproduces identically on `development` without this change; solver-tolerance sensitivity, not caused by this PR)