### PR TITLE
ci: drop redundant test run on development push, add pip caching

### DIFF
--- a/.github/workflows/build-test-publish-testPyPI.yml
+++ b/.github/workflows/build-test-publish-testPyPI.yml
@@ -2,8 +2,6 @@ name: Test and publish to TestPyPI
 
 on:
     push:
-        branches:
-            - development
         tags:
             - "v*rc*"
 
@@ -23,6 +21,11 @@ jobs:
                 uses: actions/setup-python@v6.2.0
                 with:
                     python-version: ${{ matrix.python-version }}
+                    cache: 'pip'
+                    cache-dependency-path: |
+                        setup.py
+                        setup.cfg
+                        tox.ini
             -   name: Install dependencies
                 run: |
                     python -m pip install --upgrade pip

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,11 @@ jobs:
                 uses: actions/setup-python@v6.2.0
                 with:
                     python-version: '3.13'
+                    cache: 'pip'
+                    cache-dependency-path: |
+                        setup.py
+                        setup.cfg
+                        tox.ini
             -   name: Install dependencies
                 run: |
                     python -m pip install --upgrade pip
@@ -45,6 +50,11 @@ jobs:
                 uses: actions/setup-python@v6.2.0
                 with:
                     python-version: ${{ matrix.python-version }}
+                    cache: 'pip'
+                    cache-dependency-path: |
+                        setup.py
+                        setup.cfg
+                        tox.ini
             -   name: Install Tox and any other packages
                 run: |
                     python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- `build-test-publish-testPyPI.yml` was triggered on every plain push to `development`, re-running the full lint + tox test matrix (3.10, 3.14) — duplicating what `pull-request.yml` already validates during the PR. Its `deploy-testpypi` job only runs on an `rc` tag push, so the branch-push trigger provided no value for normal merges. Restricted the workflow to `tags: v*rc*` only.
- Added `cache: 'pip'` (keyed on `setup.py`/`setup.cfg`/`tox.ini`) to the `setup-python` steps in `pull-request.yml` and `build-test-publish-testPyPI.yml` to speed up dependency installation on the jobs that remain.
- No change to the PR-triggered matrix itself — the 3.10/3.14 test jobs already run in parallel across separate runners.

## Test plan
- [x] YAML validated with `yaml.safe_load` and the repo's `check-yaml` pre-commit hook
- [ ] Confirm `pull-request.yml` still passes on this PR (uses the same trigger, so this PR itself exercises it)
- [ ] Confirm no workflow run fires on the merge commit to `development` after this merges (only tag pushes should trigger `build-test-publish-testPyPI.yml` going forward)