### PR TITLE
perf: use numba to speed up Rothfusz and Schoen heat index models

### DIFF
--- a/pythermalcomfort/models/heat_index_rothfusz.py
+++ b/pythermalcomfort/models/heat_index_rothfusz.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from numba import float64, vectorize
 
 from pythermalcomfort.classes_input import HIInputs, NumericInput
 from pythermalcomfort.classes_return import HI
@@ -65,10 +66,7 @@ def heat_index_rothfusz(
     tdb = np.asarray(tdb)
     rh = np.asarray(rh)
 
-    hi = -8.784695 + 1.61139411 * tdb + 2.338549 * rh - 0.14611605 * tdb * rh
-    hi += -1.2308094 * 10**-2 * tdb**2 - 1.6424828 * 10**-2 * rh**2
-    hi += 2.211732 * 10**-3 * tdb**2 * rh + 7.2546 * 10**-4 * tdb * rh**2
-    hi += -3.582 * 10**-6 * tdb**2 * rh**2
+    hi = _rothfusz_heat_index_optimized(tdb, rh)
 
     # heat index should only be calculated for temperatures above 27 °C
     if limit_inputs:
@@ -83,3 +81,23 @@ def heat_index_rothfusz(
         hi_valid = np.around(hi_valid, 1)
 
     return HI(hi=hi_valid, stress_category=mapping(hi_valid, heat_index_categories))
+
+
+@vectorize(
+    [
+        float64(float64, float64),
+    ],
+    cache=True,
+)
+def _rothfusz_heat_index_optimized(tdb: float64, rh: float64) -> float64:
+    return (
+        -8.784695
+        + 1.61139411 * tdb
+        + 2.338549 * rh
+        - 0.14611605 * tdb * rh
+        - 1.2308094e-2 * tdb**2
+        - 1.6424828e-2 * rh**2
+        + 2.211732e-3 * tdb**2 * rh
+        + 7.2546e-4 * tdb * rh**2
+        - 3.582e-6 * tdb**2 * rh**2
+    )

--- a/pythermalcomfort/models/heat_index_schoen.py
+++ b/pythermalcomfort/models/heat_index_schoen.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from numba import float64, vectorize
 
 from pythermalcomfort.classes_input import HIInputs, NumericInput
 from pythermalcomfort.classes_return import HI
@@ -56,7 +57,7 @@ def heat_index_schoen(
     # Calculate dew point temperature
     t_dew = psy_ta_rh(tdb, rh, p_atm=101325).dew_point_tmp
 
-    hi = tdb - 1.0799 * np.exp(0.03755 * tdb) * (1 - np.exp(0.0801 * (t_dew - 14)))
+    hi = _schoen_heat_index_optimized(tdb, t_dew)
 
     heat_index_categories = {27.0: "no risk", **HEAT_INDEX_STRESS_CATEGORIES}
 
@@ -64,3 +65,13 @@ def heat_index_schoen(
         hi = np.around(hi, 1)
 
     return HI(hi=hi, stress_category=mapping(hi, heat_index_categories))
+
+
+@vectorize(
+    [
+        float64(float64, float64),
+    ],
+    cache=True,
+)
+def _schoen_heat_index_optimized(tdb: float64, t_dew: float64) -> float64:
+    return tdb - 1.0799 * np.exp(0.03755 * tdb) * (1 - np.exp(0.0801 * (t_dew - 14)))


### PR DESCRIPTION
## Summary
- Extracts the core arithmetic of `heat_index_rothfusz` and `heat_index_schoen` into numba `@vectorize`'d scalar kernels, following the pattern already used in `utci.py`/`_pmv_ppd_optimized.py`.
- Public function signatures, input validation, `limit_inputs`, rounding, and stress-category logic are unchanged.
- Rothfusz's 9-term polynomial sees a ~5.5x speedup on large arrays (numba fuses the arithmetic into one compiled loop instead of numpy allocating a temp array per operation). Schoen's formula (2 `exp()` calls) shows no meaningful change since `np.exp` is already the bottleneck either way — kept for consistency with the rest of the HI model family.
- First step of a two-part effort; `heat_index_lu`'s iterative root-solver will be refactored for numba in a follow-up PR.

## Test plan
- [x] `pytest tests/` — 467 passed, 1 xfail (pre-existing, unrelated)
- [x] `ruff format --check` / `ruff check` — clean
- [x] Numerical parity vs. original numpy formulas verified with `np.allclose`
- [x] Benchmarked 200k-element arrays: Rothfusz 0.83ms → 0.15ms; Schoen ~unchanged