### PR TITLE
ci: drop Python 3.14 from PR test matrix

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [ '3.10', '3.14' ]
+                python-version: [ '3.10' ]
                 platform: [ ubuntu-latest ]
 
         steps:


### PR DESCRIPTION
## Summary
- Removes 3.14 from `pull-request.yml`'s test matrix, keeping just 3.10.
- Root cause (confirmed from CI logs on PR #353): `numba`'s `llvmlite` dependency has no prebuilt wheel yet for the very-new Python 3.14, so it's built from source on every PR run — `installdeps` took 215s on py3.14 vs 26s on py3.10 with equally cold pip caches, making it the dominant cost (~4 min vs ~1 min per job).
- `build-test-publish.yml` already runs the full `3.10-3.14 x ubuntu/macos/windows` matrix on every non-rc release tag, before anything publishes to PyPI, so 3.14 compatibility is still verified before a real release ships — this only removes the redundant fast-feedback copy on every PR.

## Test plan
- [x] YAML validated (`yaml.safe_load`)
- [x] Not a code change — no test suite impact; next PR's CI run will confirm the matrix behaves as expected (single 3.10 job)