### PR TITLE
perf: speed up cooling_effect by bypassing set_tmp() overhead

### DIFF
--- a/pythermalcomfort/models/cooling_effect.py
+++ b/pythermalcomfort/models/cooling_effect.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import math
 import warnings
 from typing import Literal
 
 import numpy as np
+from numba import njit
 from scipy import optimize
 
 from pythermalcomfort.classes_input import CEInputs, NumericInput
 from pythermalcomfort.classes_return import CE
-from pythermalcomfort.models.set_tmp import set_tmp
+from pythermalcomfort.models.two_nodes_gagge import _gagge_two_nodes_optimized
 from pythermalcomfort.utilities import Units, units_converter
+
+# set_tmp()/two_nodes_gagge() defaults that cooling_effect() relies on but never
+# exposes as parameters itself
+_BODY_SURFACE_AREA = 1.8258
+_P_ATM = 101325
+# two_nodes_gagge()'s calculate_ce=True path hardcodes position=1 (forces the
+# "standing" branch) regardless of the position argument, so this matches it
+_POSITION_STANDING_CODE = 1
 
 
 def cooling_effect(
@@ -147,38 +157,43 @@ def cooling_effect(
     return CE(ce=np.around(_ce, 2))
 
 
+@njit(cache=True)
+def _p_sat_torr(tdb):
+    return math.exp(18.6686 - 4030.183 / (tdb + 235.0))
+
+
+@njit(cache=True)
+def _set_for_cooling_effect(tdb, tr, v, rh, met, clo, wme):
+    # mirrors set_tmp(..., calculate_ce=True, limit_inputs=False).set, without
+    # the per-call input validation/dataclass overhead of the public API stack
+    vapor_pressure = rh * _p_sat_torr(tdb) / 100.0
+    return _gagge_two_nodes_optimized(
+        tdb,
+        tr,
+        v,
+        met,
+        clo,
+        vapor_pressure,
+        wme,
+        _BODY_SURFACE_AREA,
+        _P_ATM,
+        _POSITION_STANDING_CODE,
+        calculate_ce=True,
+    )[0]
+
+
 @np.vectorize
 def _cooling_effect_vectorised(tdb, tr, still_air_threshold, rh, met, clo, wme, vr):
     if vr <= 0.1:
         return 0.0
 
-    initial_set_tmp = set_tmp(
-        tdb=tdb,
-        tr=tr,
-        v=vr,
-        rh=rh,
-        met=met,
-        clo=clo,
-        wme=wme,
-        round_output=False,
-        calculate_ce=True,
-        limit_inputs=False,
-    ).set
+    initial_set_tmp = _set_for_cooling_effect(tdb, tr, vr, rh, met, clo, wme)
 
     def function(x):
         return (
-            set_tmp(
-                tdb=tdb - x,
-                tr=tr - x,
-                v=still_air_threshold,
-                rh=rh,
-                met=met,
-                clo=clo,
-                wme=wme,
-                round_output=False,
-                calculate_ce=True,
-                limit_inputs=False,
-            ).set
+            _set_for_cooling_effect(
+                tdb - x, tr - x, still_air_threshold, rh, met, clo, wme
+            )
             - initial_set_tmp
         )
 

--- a/tests/test_cooling_effect.py
+++ b/tests/test_cooling_effect.py
@@ -1,5 +1,37 @@
+import numpy as np
+
 from pythermalcomfort.models import cooling_effect
 from tests.conftest import Urls, retrieve_reference_table, validate_result
+
+
+def test_cooling_effect_regression_values() -> None:
+    """Pin ce against the reference (pre-numba) implementation.
+
+    Values were captured from the implementation before its inner SET
+    calculation was rewritten to call the numba-jitted Gagge kernel directly
+    (instead of going through the full set_tmp()/two_nodes_gagge() public API
+    on every root-finding iteration). Confirmed to match bit-for-bit across a
+    wide random sweep plus edge cases (vr <= 0.1, vr == 0.1 boundary).
+    """
+    cases = [
+        (25, 25, 0.05, 50, 1.2, 0.5, 0.0),  # vr <= 0.1 -> 0
+        (25, 25, 0.1, 50, 1.2, 0.5, 0.0),  # boundary
+        (25, 25, 0.3, 50, 1.2, 0.5, 1.68),
+        (35, 35, 1.5, 90, 2.5, 0.2, 5.14),
+        (15, 15, 0.5, 10, 1.0, 1.2, 2.61),
+    ]
+    for tdb, tr, vr, rh, met, clo, expected in cases:
+        ce = cooling_effect(tdb=tdb, tr=tr, vr=vr, rh=rh, met=met, clo=clo).ce
+        assert np.isclose(ce, expected, atol=0.01), (
+            tdb,
+            tr,
+            vr,
+            rh,
+            met,
+            clo,
+            ce,
+            expected,
+        )
 
 
 def test_cooling_effect(get_test_url, retrieve_data) -> None:


### PR DESCRIPTION
## Summary
Closes #358.

- `cooling_effect`'s root-finding loop (`scipy.optimize.brentq`) called the full public `set_tmp()` API on every iteration — input validation dataclasses, array conversions, output dataclass construction — even though `set_tmp` already delegates to the numba-jitted `_gagge_two_nodes_optimized` kernel underneath.
- Added a small `@njit` helper (`_set_for_cooling_effect`) that computes `vapor_pressure` and calls `_gagge_two_nodes_optimized` directly, mirroring `set_tmp(calculate_ce=True, limit_inputs=False)` exactly (hardcoded `body_surface_area=1.8258`, `p_atm=101325`, `position=1` — matching defaults/behavior `cooling_effect` already relied on implicitly, since it never exposes those as parameters).
- Kept `scipy.optimize.brentq` for the root-find itself — it already converges reliably, and swapping solver algorithms risked subtle numerical drift for no real benefit. The entire win comes from making each residual evaluation cheap.

## Verification
- Bit-for-bit identical output (rounded and unrounded) vs. the pre-refactor implementation across 300 random samples plus edge cases (`vr <= 0.1`, `vr == 0.1` boundary) — max abs diff `0.0`.
- Added `test_cooling_effect_regression_values`, pinning 5 reference values.
- Benchmark: ~10x speedup (0.36 ms/elem → 0.04 ms/elem).

## Test plan
- [x] `pytest tests/` — 469 passed, 1 xfail (pre-existing, unrelated)
- [x] `ruff format --check` / `ruff check` — clean