### PR TITLE
Release 4.1.1: cooling_effect/solar_gain numba speedups, pillow security pin

### DIFF
--- a/.github/workflows/build-test-publish-testPyPI.yml
+++ b/.github/workflows/build-test-publish-testPyPI.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [ "3.10", "3.14" ]
+                python-version: [ "3.13" ]
                 platform: [ ubuntu-latest ]
         steps:
             -   uses: actions/checkout@v6.0.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+4.1.1 (2026-07-20)
+------------------
+
+* Sped up ``cooling_effect`` (~10x) by calling the already numba-jitted Gagge
+  two-node kernel directly instead of the full ``set_tmp()`` public API on
+  every root-finding iteration.
+* Sped up ``solar_gain`` (~100x+) with numba: table-based interpolation and
+  posture handling converted to JIT-compiled code.
+* Pinned ``pillow>=10.3.0`` in docs requirements to resolve a transitive
+  Snyk-flagged vulnerability.
+* Reduced the ``build-test-publish-testPyPI.yml`` CI matrix to speed up
+  TestPyPI release checks.
+
 4.1.0 (2026-07-20)
 ------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ sphinx
 sphinx-rtd-theme
 docutils
 urllib3>=2.6.3
+pillow>=10.3.0
 pydata-sphinx-theme
 sphinx-copybutton
 matplotlib

--- a/pythermalcomfort/models/cooling_effect.py
+++ b/pythermalcomfort/models/cooling_effect.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import math
 import warnings
 from typing import Literal
 
 import numpy as np
+from numba import njit
 from scipy import optimize
 
 from pythermalcomfort.classes_input import CEInputs, NumericInput
 from pythermalcomfort.classes_return import CE
-from pythermalcomfort.models.set_tmp import set_tmp
+from pythermalcomfort.models.two_nodes_gagge import _gagge_two_nodes_optimized
 from pythermalcomfort.utilities import Units, units_converter
+
+# set_tmp()/two_nodes_gagge() defaults that cooling_effect() relies on but never
+# exposes as parameters itself
+_BODY_SURFACE_AREA = 1.8258
+_P_ATM = 101325
+# two_nodes_gagge()'s calculate_ce=True path hardcodes position=1 (forces the
+# "standing" branch) regardless of the position argument, so this matches it
+_POSITION_STANDING_CODE = 1
 
 
 def cooling_effect(
@@ -147,38 +157,43 @@ def cooling_effect(
     return CE(ce=np.around(_ce, 2))
 
 
+@njit(cache=True)
+def _p_sat_torr(tdb):
+    return math.exp(18.6686 - 4030.183 / (tdb + 235.0))
+
+
+@njit(cache=True)
+def _set_for_cooling_effect(tdb, tr, v, rh, met, clo, wme):
+    # mirrors set_tmp(..., calculate_ce=True, limit_inputs=False).set, without
+    # the per-call input validation/dataclass overhead of the public API stack
+    vapor_pressure = rh * _p_sat_torr(tdb) / 100.0
+    return _gagge_two_nodes_optimized(
+        tdb,
+        tr,
+        v,
+        met,
+        clo,
+        vapor_pressure,
+        wme,
+        _BODY_SURFACE_AREA,
+        _P_ATM,
+        _POSITION_STANDING_CODE,
+        calculate_ce=True,
+    )[0]
+
+
 @np.vectorize
 def _cooling_effect_vectorised(tdb, tr, still_air_threshold, rh, met, clo, wme, vr):
     if vr <= 0.1:
         return 0.0
 
-    initial_set_tmp = set_tmp(
-        tdb=tdb,
-        tr=tr,
-        v=vr,
-        rh=rh,
-        met=met,
-        clo=clo,
-        wme=wme,
-        round_output=False,
-        calculate_ce=True,
-        limit_inputs=False,
-    ).set
+    initial_set_tmp = _set_for_cooling_effect(tdb, tr, vr, rh, met, clo, wme)
 
     def function(x):
         return (
-            set_tmp(
-                tdb=tdb - x,
-                tr=tr - x,
-                v=still_air_threshold,
-                rh=rh,
-                met=met,
-                clo=clo,
-                wme=wme,
-                round_output=False,
-                calculate_ce=True,
-                limit_inputs=False,
-            ).set
+            _set_for_cooling_effect(
+                tdb - x, tr - x, still_air_threshold, rh, met, clo, wme
+            )
             - initial_set_tmp
         )
 

--- a/pythermalcomfort/models/solar_gain.py
+++ b/pythermalcomfort/models/solar_gain.py
@@ -251,8 +251,18 @@ def solar_gain(
 
 @njit(cache=True)
 def _find_span(arr, x):
+    # range(n - 1), not range(n): the original pure Python loop iterated
+    # range(len(arr)) and relied on valid (in-range) inputs always matching
+    # before the last iteration read arr[i + 1] one past the end - out of
+    # range inputs would raise IndexError there. In the numba version this
+    # is called from a prange-parallelized loop (_solar_gain_array), and
+    # numba does not propagate exceptions raised inside prange loops, so an
+    # out-of-bounds read there would silently return garbage rather than a
+    # clean error. Stopping one iteration early avoids the out-of-bounds
+    # read entirely; out-of-range inputs now return -1 (same as any other
+    # unmatched span) instead of raising.
     n = arr.shape[0]
-    for i in range(n):
+    for i in range(n - 1):
         if arr[i + 1] >= x >= arr[i]:
             return i
     return -1

--- a/pythermalcomfort/models/solar_gain.py
+++ b/pythermalcomfort/models/solar_gain.py
@@ -3,10 +3,66 @@ from __future__ import annotations
 import math
 
 import numpy as np
+from numba import njit, prange
 
 from pythermalcomfort.classes_input import NumericInput, SolarGainInputs
 from pythermalcomfort.classes_return import SolarGain
 from pythermalcomfort.utilities import Postures, transpose_sharp_altitude
+
+# integer codes for posture, since numba nopython mode can't dispatch on
+# Python string/enum comparisons the way the rest of this module's helpers do
+_POSTURE_STANDING = 0
+_POSTURE_SITTING = 1
+_POSTURE_SUPINE = 2
+
+_POSTURE_CODES = {
+    Postures.standing.value: _POSTURE_STANDING,
+    Postures.sitting.value: _POSTURE_SITTING,
+    Postures.supine.value: _POSTURE_SUPINE,
+}
+
+_ALT_RANGE = np.array([0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0])
+_AZ_RANGE = np.array(
+    [0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 105.0, 120.0, 135.0, 150.0, 165.0, 180.0]
+)
+
+# fp is the projected area factor, standing/supine
+_FP_TABLE_STANDING = np.array(
+    [
+        [0.35, 0.35, 0.314, 0.258, 0.206, 0.144, 0.082],
+        [0.342, 0.342, 0.31, 0.252, 0.2, 0.14, 0.082],
+        [0.33, 0.33, 0.3, 0.244, 0.19, 0.132, 0.082],
+        [0.31, 0.31, 0.275, 0.228, 0.175, 0.124, 0.082],
+        [0.283, 0.283, 0.251, 0.208, 0.16, 0.114, 0.082],
+        [0.252, 0.252, 0.228, 0.188, 0.15, 0.108, 0.082],
+        [0.23, 0.23, 0.214, 0.18, 0.148, 0.108, 0.082],
+        [0.242, 0.242, 0.222, 0.18, 0.153, 0.112, 0.082],
+        [0.274, 0.274, 0.245, 0.203, 0.165, 0.116, 0.082],
+        [0.304, 0.304, 0.27, 0.22, 0.174, 0.121, 0.082],
+        [0.328, 0.328, 0.29, 0.234, 0.183, 0.125, 0.082],
+        [0.344, 0.344, 0.304, 0.244, 0.19, 0.128, 0.082],
+        [0.347, 0.347, 0.308, 0.246, 0.191, 0.128, 0.082],
+    ]
+)
+
+# fp table, sitting
+_FP_TABLE_SITTING = np.array(
+    [
+        [0.29, 0.324, 0.305, 0.303, 0.262, 0.224, 0.177],
+        [0.292, 0.328, 0.294, 0.288, 0.268, 0.227, 0.177],
+        [0.288, 0.332, 0.298, 0.29, 0.264, 0.222, 0.177],
+        [0.274, 0.326, 0.294, 0.289, 0.252, 0.214, 0.177],
+        [0.254, 0.308, 0.28, 0.276, 0.241, 0.202, 0.177],
+        [0.23, 0.282, 0.262, 0.26, 0.233, 0.193, 0.177],
+        [0.216, 0.26, 0.248, 0.244, 0.22, 0.186, 0.177],
+        [0.234, 0.258, 0.236, 0.227, 0.208, 0.18, 0.177],
+        [0.262, 0.26, 0.224, 0.208, 0.196, 0.176, 0.177],
+        [0.28, 0.26, 0.21, 0.192, 0.184, 0.17, 0.177],
+        [0.298, 0.256, 0.194, 0.174, 0.168, 0.168, 0.177],
+        [0.306, 0.25, 0.18, 0.156, 0.156, 0.166, 0.177],
+        [0.3, 0.24, 0.168, 0.152, 0.152, 0.164, 0.177],
+    ]
+)
 
 
 def solar_gain(
@@ -142,27 +198,49 @@ def solar_gain(
     floor_reflectance = np.asarray(floor_reflectance)
 
     posture = posture.lower()
-    if posture not in [
-        Postures.standing.value,
-        Postures.supine.value,
-        Postures.sitting.value,
-    ]:
+    if posture not in _POSTURE_CODES:
         error_msg_posture = (
             "Posture has to be either 'standing', 'supine' or 'sitting'."
         )
         raise ValueError(error_msg_posture)
+    posture_code = np.asarray(_POSTURE_CODES[posture])
 
-    erf, d_mrt = _solar_gain_vectorised(
-        sol_altitude=sol_altitude,
-        sharp=sharp,
-        sol_radiation_dir=sol_radiation_dir,
-        sol_transmittance=sol_transmittance,
-        f_svv=f_svv,
-        f_bes=f_bes,
-        asw=asw,
-        floor_reflectance=floor_reflectance,
-        posture=posture,
+    (
+        sol_altitude_b,
+        sharp_b,
+        sol_radiation_dir_b,
+        sol_transmittance_b,
+        f_svv_b,
+        f_bes_b,
+        asw_b,
+        floor_reflectance_b,
+        posture_code_b,
+    ) = np.broadcast_arrays(
+        sol_altitude,
+        sharp,
+        sol_radiation_dir,
+        sol_transmittance,
+        f_svv,
+        f_bes,
+        asw,
+        floor_reflectance,
+        posture_code,
     )
+    output_shape = sol_altitude_b.shape
+
+    erf, d_mrt = _solar_gain_array(
+        sol_altitude=np.ravel(sol_altitude_b).astype(np.float64),
+        sharp=np.ravel(sharp_b).astype(np.float64),
+        sol_radiation_dir=np.ravel(sol_radiation_dir_b).astype(np.float64),
+        sol_transmittance=np.ravel(sol_transmittance_b).astype(np.float64),
+        f_svv=np.ravel(f_svv_b).astype(np.float64),
+        f_bes=np.ravel(f_bes_b).astype(np.float64),
+        asw=np.ravel(asw_b).astype(np.float64),
+        floor_reflectance=np.ravel(floor_reflectance_b).astype(np.float64),
+        posture_code=np.ravel(posture_code_b).astype(np.int64),
+    )
+    erf = erf.reshape(output_shape)
+    d_mrt = d_mrt.reshape(output_shape)
 
     if round_output:
         erf = np.round(erf, 1)
@@ -171,8 +249,17 @@ def solar_gain(
     return SolarGain(erf=erf, delta_mrt=d_mrt)
 
 
-@np.vectorize
-def _solar_gain_vectorised(
+@njit(cache=True)
+def _find_span(arr, x):
+    n = arr.shape[0]
+    for i in range(n):
+        if arr[i + 1] >= x >= arr[i]:
+            return i
+    return -1
+
+
+@njit(cache=True)
+def _solar_gain_scalar(
     sol_altitude,
     sharp,
     sol_radiation_dir,
@@ -180,67 +267,31 @@ def _solar_gain_vectorised(
     f_svv,
     f_bes,
     asw,
-    posture,
     floor_reflectance,
+    posture_code,
 ):
-    def find_span(arr, x):
-        for i in range(len(arr)):
-            if arr[i + 1] >= x >= arr[i]:
-                return i
-        return -1
-
     deg_to_rad = 0.0174532925
     hr = 6
     i_diff = 0.2 * sol_radiation_dir
 
-    # fp is the projected area factor
-    fp_table = [
-        [0.35, 0.35, 0.314, 0.258, 0.206, 0.144, 0.082],
-        [0.342, 0.342, 0.31, 0.252, 0.2, 0.14, 0.082],
-        [0.33, 0.33, 0.3, 0.244, 0.19, 0.132, 0.082],
-        [0.31, 0.31, 0.275, 0.228, 0.175, 0.124, 0.082],
-        [0.283, 0.283, 0.251, 0.208, 0.16, 0.114, 0.082],
-        [0.252, 0.252, 0.228, 0.188, 0.15, 0.108, 0.082],
-        [0.23, 0.23, 0.214, 0.18, 0.148, 0.108, 0.082],
-        [0.242, 0.242, 0.222, 0.18, 0.153, 0.112, 0.082],
-        [0.274, 0.274, 0.245, 0.203, 0.165, 0.116, 0.082],
-        [0.304, 0.304, 0.27, 0.22, 0.174, 0.121, 0.082],
-        [0.328, 0.328, 0.29, 0.234, 0.183, 0.125, 0.082],
-        [0.344, 0.344, 0.304, 0.244, 0.19, 0.128, 0.082],
-        [0.347, 0.347, 0.308, 0.246, 0.191, 0.128, 0.082],
-    ]
-    if posture == Postures.sitting.value:
-        fp_table = [
-            [0.29, 0.324, 0.305, 0.303, 0.262, 0.224, 0.177],
-            [0.292, 0.328, 0.294, 0.288, 0.268, 0.227, 0.177],
-            [0.288, 0.332, 0.298, 0.29, 0.264, 0.222, 0.177],
-            [0.274, 0.326, 0.294, 0.289, 0.252, 0.214, 0.177],
-            [0.254, 0.308, 0.28, 0.276, 0.241, 0.202, 0.177],
-            [0.23, 0.282, 0.262, 0.26, 0.233, 0.193, 0.177],
-            [0.216, 0.26, 0.248, 0.244, 0.22, 0.186, 0.177],
-            [0.234, 0.258, 0.236, 0.227, 0.208, 0.18, 0.177],
-            [0.262, 0.26, 0.224, 0.208, 0.196, 0.176, 0.177],
-            [0.28, 0.26, 0.21, 0.192, 0.184, 0.17, 0.177],
-            [0.298, 0.256, 0.194, 0.174, 0.168, 0.168, 0.177],
-            [0.306, 0.25, 0.18, 0.156, 0.156, 0.166, 0.177],
-            [0.3, 0.24, 0.168, 0.152, 0.152, 0.164, 0.177],
-        ]
+    if posture_code == _POSTURE_SITTING:
+        fp_table = _FP_TABLE_SITTING
+    else:
+        fp_table = _FP_TABLE_STANDING
 
-    if posture == Postures.supine.value:
+    if posture_code == _POSTURE_SUPINE:
         sharp, sol_altitude = transpose_sharp_altitude(sharp, sol_altitude)
 
-    alt_range = [0, 15, 30, 45, 60, 75, 90]
-    az_range = [0, 15, 30, 45, 60, 75, 90, 105, 120, 135, 150, 165, 180]
-    alt_i = find_span(alt_range, sol_altitude)
-    az_i = find_span(az_range, sharp)
-    fp11 = fp_table[az_i][alt_i]
-    fp12 = fp_table[az_i][alt_i + 1]
-    fp21 = fp_table[az_i + 1][alt_i]
-    fp22 = fp_table[az_i + 1][alt_i + 1]
-    az1 = az_range[az_i]
-    az2 = az_range[az_i + 1]
-    alt1 = alt_range[alt_i]
-    alt2 = alt_range[alt_i + 1]
+    alt_i = _find_span(_ALT_RANGE, sol_altitude)
+    az_i = _find_span(_AZ_RANGE, sharp)
+    fp11 = fp_table[az_i, alt_i]
+    fp12 = fp_table[az_i, alt_i + 1]
+    fp21 = fp_table[az_i + 1, alt_i]
+    fp22 = fp_table[az_i + 1, alt_i + 1]
+    az1 = _AZ_RANGE[az_i]
+    az2 = _AZ_RANGE[az_i + 1]
+    alt1 = _ALT_RANGE[alt_i]
+    alt2 = _ALT_RANGE[alt_i + 1]
     fp = fp11 * (az2 - sharp) * (alt2 - sol_altitude)
     fp += fp21 * (sharp - az1) * (alt2 - sol_altitude)
     fp += fp12 * (az2 - sharp) * (sol_altitude - alt1)
@@ -248,7 +299,7 @@ def _solar_gain_vectorised(
     fp /= (az2 - az1) * (alt2 - alt1)
 
     f_eff = 0.725  # fraction of the body surface exposed to environmental radiation
-    if posture == Postures.sitting.value:
+    if posture_code == _POSTURE_SITTING:
         f_eff = 0.696
 
     sw_abs = asw
@@ -269,4 +320,34 @@ def _solar_gain_vectorised(
     erf = e_solar * (sw_abs / lw_abs)
     d_mrt = erf / (hr * f_eff)
 
+    return erf, d_mrt
+
+
+@njit(cache=True, parallel=True)
+def _solar_gain_array(
+    sol_altitude,
+    sharp,
+    sol_radiation_dir,
+    sol_transmittance,
+    f_svv,
+    f_bes,
+    asw,
+    floor_reflectance,
+    posture_code,
+):
+    n = sol_altitude.shape[0]
+    erf = np.empty(n, dtype=np.float64)
+    d_mrt = np.empty(n, dtype=np.float64)
+    for i in prange(n):
+        erf[i], d_mrt[i] = _solar_gain_scalar(
+            sol_altitude[i],
+            sharp[i],
+            sol_radiation_dir[i],
+            sol_transmittance[i],
+            f_svv[i],
+            f_bes[i],
+            asw[i],
+            floor_reflectance[i],
+            posture_code[i],
+        )
     return erf, d_mrt

--- a/pythermalcomfort/utilities.py
+++ b/pythermalcomfort/utilities.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import NamedTuple
 
 import numpy as np
+from numba import njit
 from numpy.typing import NDArray
 
 from pythermalcomfort.classes_return import PsychrometricValues
@@ -471,6 +472,7 @@ def validate_type(value, name: str, allowed_types: tuple):
         raise TypeError(invalid_type_msg)
 
 
+@njit(cache=True)
 def transpose_sharp_altitude(sharp: float, altitude: float) -> tuple[float, float]:
     """Transpose the solar altitude and solar azimuth angles."""
     altitude_new = math.degrees(

--- a/tests/test_cooling_effect.py
+++ b/tests/test_cooling_effect.py
@@ -5,13 +5,16 @@ from tests.conftest import Urls, retrieve_reference_table, validate_result
 
 
 def test_cooling_effect_regression_values() -> None:
-    """Pin ce against the reference (pre-numba) implementation.
+    """Pin ce against the reference (pre-refactor) implementation.
 
-    Values were captured from the implementation before its inner SET
-    calculation was rewritten to call the numba-jitted Gagge kernel directly
-    (instead of going through the full set_tmp()/two_nodes_gagge() public API
-    on every root-finding iteration). Confirmed to match bit-for-bit across a
-    wide random sweep plus edge cases (vr <= 0.1, vr == 0.1 boundary).
+    The previous implementation already called the numba-jitted Gagge kernel
+    (via set_tmp()/two_nodes_gagge()) - it wasn't slow because it lacked
+    numba, but because every root-finding iteration re-ran the full public
+    set_tmp() API (input validation, dataclass construction, etc.) on top of
+    that kernel. Values were captured before the inner SET calculation was
+    rewritten to call the jitted kernel directly, skipping that overhead.
+    Confirmed to match bit-for-bit across a wide random sweep plus edge cases
+    (vr <= 0.1, vr == 0.1 boundary).
     """
     cases = [
         (25, 25, 0.05, 50, 1.2, 0.5, 0.0),  # vr <= 0.1 -> 0

--- a/tests/test_cooling_effect.py
+++ b/tests/test_cooling_effect.py
@@ -1,5 +1,37 @@
+import numpy as np
+
 from pythermalcomfort.models import cooling_effect
 from tests.conftest import Urls, retrieve_reference_table, validate_result
+
+
+def test_cooling_effect_regression_values() -> None:
+    """Pin ce against the reference (pre-numba) implementation.
+
+    Values were captured from the implementation before its inner SET
+    calculation was rewritten to call the numba-jitted Gagge kernel directly
+    (instead of going through the full set_tmp()/two_nodes_gagge() public API
+    on every root-finding iteration). Confirmed to match bit-for-bit across a
+    wide random sweep plus edge cases (vr <= 0.1, vr == 0.1 boundary).
+    """
+    cases = [
+        (25, 25, 0.05, 50, 1.2, 0.5, 0.0),  # vr <= 0.1 -> 0
+        (25, 25, 0.1, 50, 1.2, 0.5, 0.0),  # boundary
+        (25, 25, 0.3, 50, 1.2, 0.5, 1.68),
+        (35, 35, 1.5, 90, 2.5, 0.2, 5.14),
+        (15, 15, 0.5, 10, 1.0, 1.2, 2.61),
+    ]
+    for tdb, tr, vr, rh, met, clo, expected in cases:
+        ce = cooling_effect(tdb=tdb, tr=tr, vr=vr, rh=rh, met=met, clo=clo).ce
+        assert np.isclose(ce, expected, atol=0.01), (
+            tdb,
+            tr,
+            vr,
+            rh,
+            met,
+            clo,
+            ce,
+            expected,
+        )
 
 
 def test_cooling_effect(get_test_url, retrieve_data) -> None:

--- a/tests/test_solar_gain.py
+++ b/tests/test_solar_gain.py
@@ -21,6 +21,37 @@ def test_solar_gain(get_test_url, retrieve_data) -> None:
         validate_result(result, outputs, tolerance)
 
 
+def test_solar_gain_regression_values() -> None:
+    """Pin erf/delta_mrt against the reference (pre-numba) implementation.
+
+    Values were captured from the implementation before its table-lookup
+    kernel was rewritten for numba (posture strings -> integer codes, table
+    lists -> np.array, plain-Python loop -> njit/prange). Confirmed to match
+    bit-for-bit across a wide random sweep (all 3 postures) plus exact grid
+    boundary points.
+    """
+    cases = [
+        (0, 120, 800, 0.5, 0.5, 0.5, "sitting", 43.2839, 10.3649),
+        (30, 60, 600, 0.6, 0.4, 0.6, "standing", 52.8099, 12.1402),
+        (45, 90, 500, 0.7, 0.3, 0.7, "supine", 49.548, 11.3904),
+        (90, 0, 1000, 1.0, 1.0, 1.0, "sitting", 326.6804, 78.2281),
+        (15, 165, 250, 0.2, 0.1, 0.9, "standing", 8.9043, 2.047),
+    ]
+    for alt, sharp, rad, trans, svv, bes, posture, exp_erf, exp_d_mrt in cases:
+        result = solar_gain(
+            sol_altitude=alt,
+            sharp=sharp,
+            sol_radiation_dir=rad,
+            sol_transmittance=trans,
+            f_svv=svv,
+            f_bes=bes,
+            posture=posture,
+            round_output=False,
+        )
+        assert np.isclose(result.erf, exp_erf, atol=1e-3)
+        assert np.isclose(result.delta_mrt, exp_d_mrt, atol=1e-3)
+
+
 def test_solar_gain_array() -> None:
     """Test that the solar gain function works with arrays."""
     np.allclose(


### PR DESCRIPTION
## Summary
Ships everything merged into development since 4.1.0:
- perf: cooling_effect speedup (~10x) - bypasses set_tmp() overhead, calls jitted Gagge kernel directly (#358, #362)
- perf: solar_gain speedup (~100x+) - table interpolation + posture handling converted to numba (#361, #363)
- fix: pin pillow>=10.3.0 in docs requirements (Snyk vulnerability)
- ci: reduce build-test-publish-testPyPI.yml matrix

No TestPyPI dry-run for this release per explicit request - all changes were already bit-for-bit verified against the pre-refactor implementations and full-suite CI-green before merging into development.

## Test plan
- [x] Each change individually verified: bit-for-bit parity vs. pre-refactor implementation, full test suite, ruff clean, benchmarked
- [x] CodeRabbit CLI review run on solar_gain changes, finding fixed (out-of-bounds read under prange)